### PR TITLE
connection: read `verify_hostname` from configuration

### DIFF
--- a/src/qh3/quic/connection.py
+++ b/src/qh3/quic/connection.py
@@ -1333,6 +1333,7 @@ class QuicConnection:
             verify_mode=self._configuration.verify_mode,
             hostname_checks_common_name=self._configuration.hostname_checks_common_name,
             assert_fingerprint=self._configuration.assert_fingerprint,
+            verify_hostname=self._configuration.verify_hostname,
         )
         self.tls.certificate = self._configuration.certificate
         self.tls.certificate_chain = self._configuration.certificate_chain


### PR DESCRIPTION
Currently, the `verify_hostname` option is settable from the configuration, but the `QuicConnection` is always initiazlied with it being `True`, instead of getting the value from the user.