### PR TITLE
:sparkle: Add x509 helper for niquests sole usage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@
 **Added**
 - Exposed ``CipherSuite`` and ``SessionTicket`` classes in the top-level import.
 
+**Misc**
+- Exposed a x509 helper to make for ``cryptography`` dependency removal, solely for Niquests usage.
+
 1.0.0 (2024-04-18)
 =====================
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
+ "der_derive",
+ "flagset",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -386,6 +388,17 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rusticata-macros",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fe87ce4529967e0ba1dcf8450bab64d97dfd5010a6256187ffe2e43e6f0e049"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -487,6 +500,12 @@ name = "fiat-crypto"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
+
+[[package]]
+name = "flagset"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb3aa5e95cf9aabc17f060cfa0ced7b83f042390760ca53bf09df9968acaa1"
 
 [[package]]
 name = "fs_extra"
@@ -998,11 +1017,12 @@ dependencies = [
 
 [[package]]
 name = "qh3"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "aes",
  "aws-lc-rs",
  "chacha20poly1305",
+ "der",
  "dsa",
  "ed25519-dalek",
  "ls-qpack",
@@ -1013,6 +1033,9 @@ dependencies = [
  "rsa",
  "rustls",
  "rustls-pemfile",
+ "sha1",
+ "x509-cert",
+ "x509-ocsp",
  "x509-parser",
 ]
 
@@ -1272,6 +1295,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1443,27 @@ checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tls_codec"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e78c9c330f8c85b2bae7c8368f2739157db9991235123aa1b15ef9502bfb6a"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d9ef545650e79f30233c0003bcc2504d7efac6dad25fca40744de773fe2049c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1599,6 +1654,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid",
+ "der",
+ "spki",
+ "tls_codec",
+]
+
+[[package]]
+name = "x509-ocsp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e54e695a31f0fecb826cf59ae2093c941d7ef932a1f8508185dd23b29ce2e2e"
+dependencies = [
+ "const-oid",
+ "der",
+ "digest",
+ "rand_core",
+ "signature",
+ "spki",
+ "x509-cert",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1621,3 +1703,17 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qh3"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3"
@@ -27,6 +27,10 @@ pkcs8 = {version = "0.10.2", features = ["encryption", "pem", "alloc"]}
 pkcs1 = {version = "0.7.5", features = ["alloc", "pem"]}
 rustls-pemfile = {version = "2.1.2"}
 aws-lc-rs = {version = "1.7.0", features=["bindgen"]}
+x509-ocsp = {version = "0.2.1", features = ["builder"]}
+x509-cert = "0.2.5"
+der = {version = "0.7.9", features = ["alloc"]}
+sha1 = {version = "0.10.6", features = ["oid"]}
 
 [package.metadata.maturin]
 python-source = "qh3"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,25 +1,26 @@
-aioquic
-=======
+qh3
+====
 
-|pypi-v| |pypi-pyversions| |pypi-l| |tests| |codecov|
+|pypi-v| |pypi-pyversions| |pypi-l|
 
-.. |pypi-v| image:: https://img.shields.io/pypi/v/aioquic.svg
+.. |pypi-v| image:: https://img.shields.io/pypi/v/qh3.svg
     :target: https://pypi.python.org/pypi/aioquic
 
-.. |pypi-pyversions| image:: https://img.shields.io/pypi/pyversions/aioquic.svg
+.. |pypi-pyversions| image:: https://img.shields.io/pypi/pyversions/qh3.svg
     :target: https://pypi.python.org/pypi/aioquic
 
 .. |pypi-l| image:: https://img.shields.io/pypi/l/aioquic.svg
     :target: https://pypi.python.org/pypi/aioquic
 
-.. |tests| image:: https://github.com/aiortc/aioquic/workflows/tests/badge.svg
-    :target: https://github.com/aiortc/aioquic/actions
+``qh3`` is a library for the QUIC network protocol in Python. It is a maintained fork of the ``aioquic`` library.
+``aioquic`` is still maintained, but we decided to diverge as qh3 took a path that is in opposition to their wishes.
 
-.. |codecov| image:: https://img.shields.io/codecov/c/github/aiortc/aioquic.svg
-    :target: https://codecov.io/gh/aiortc/aioquic
+It is lighter, and a bit faster, and more adapted to a broader audience as this package has no external dependency
+and does not rely on mainstream OpenSSL.
 
-``aioquic`` is a library for the QUIC network protocol in Python. It features several
-APIs:
+While it is a compatible fork, it is not a drop-in replacement since the first major. See the CHANGELOG for details.
+
+It features several APIs:
 
 - a QUIC API following the "bring your own I/O" pattern, suitable for
   embedding in any framework,

--- a/qh3/_hazmat.pyi
+++ b/qh3/_hazmat.pyi
@@ -167,3 +167,43 @@ class SignatureError(Exception): ...
 class QUICHeaderProtection:
     def __init__(self, key: bytes, algorithm: int) -> None: ...
     def mask(self, sample: bytes) -> bytes: ...
+
+class ReasonFlags(Enum):
+    unspecified = 0
+    key_compromise = 1
+    ca_compromise = 2
+    affiliation_changed = 3
+    superseded = 4
+    cessation_of_operation = 5
+    certificate_hold = 6
+    privilege_withdrawn = 9
+    aa_compromise = 10
+    remove_from_crl = 8
+
+class OCSPResponseStatus(Enum):
+    SUCCESSFUL = 0
+    MALFORMED_REQUEST = 1
+    INTERNAL_ERROR = 2
+    TRY_LATER = 3
+    SIG_REQUIRED = 5
+    UNAUTHORIZED = 6
+
+class OCSPCertStatus(Enum):
+    GOOD = 0
+    REVOKED = 1
+    UNKNOWN = 2
+
+class OCSPResponse:
+    def __init__(self, raw_response: bytes) -> None: ...
+    @property
+    def next_update(self) -> int: ...
+    @property
+    def response_status(self) -> OCSPResponseStatus: ...
+    @property
+    def certificate_status(self) -> OCSPCertStatus: ...
+    @property
+    def revocation_reason(self) -> ReasonFlags | None: ...
+
+class OCSPRequest:
+    def __init__(self, peer_certificate: bytes, issuer_certificate: bytes) -> None: ...
+    def public_bytes(self) -> bytes: ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod agreement;
 mod private_key;
 mod pkcs8;
 mod hpk;
+mod ocsp;
 
 pub use self::headers::{QpackDecoder, QpackEncoder, StreamBlocked, EncoderStreamError, DecoderStreamError, DecompressionFailed};
 pub use self::aead::{AeadChaCha20Poly1305, AeadAes128Gcm, AeadAes256Gcm};
@@ -18,6 +19,7 @@ pub use self::private_key::{RsaPrivateKey, DsaPrivateKey, Ed25519PrivateKey, EcP
 pub use self::agreement::{X25519KeyExchange, ECDHP256KeyExchange, ECDHP384KeyExchange, ECDHP521KeyExchange};
 pub use self::pkcs8::{PrivateKeyInfo, KeyType};
 pub use self::hpk::{QUICHeaderProtection};
+pub use self::ocsp::{OCSPResponse, OCSPCertStatus, OCSPResponseStatus, ReasonFlags, OCSPRequest};
 
 pyo3::create_exception!(_hazmat, CryptoError, PyException);
 
@@ -61,5 +63,11 @@ fn _hazmat(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<ECDHP521KeyExchange>()?;
     // General Crypto Error
     m.add("CryptoError", py.get_type::<CryptoError>())?;
+    // Niquests OCSP helper
+    m.add_class::<OCSPResponse>()?;
+    m.add_class::<OCSPCertStatus>()?;
+    m.add_class::<OCSPResponseStatus>()?;
+    m.add_class::<ReasonFlags>()?;
+    m.add_class::<OCSPRequest>()?;
     Ok(())
 }

--- a/src/ocsp.rs
+++ b/src/ocsp.rs
@@ -1,0 +1,175 @@
+// OCSP Response Parser and Request Builder
+// This module is created for Niquests
+// qh3 has no use for it and we won't implement it for this package
+use pyo3::{PyResult, Python};
+use pyo3::types::PyBytes;
+use pyo3::pymethods;
+use pyo3::pyclass;
+
+use der::{Decode, Encode};
+use pyo3::exceptions::PyValueError;
+use x509_ocsp::{OcspResponse, BasicOcspResponse, SingleResponse, OcspResponseStatus as InternalOcspResponseStatus, CertStatus as InternalCertStatus, OcspRequest as InternalOcspRequest, Request};
+use x509_ocsp::builder::OcspRequestBuilder;
+use x509_cert::Certificate;
+
+use sha1::Sha1;
+
+#[pyclass(module = "qh3._hazmat")]
+#[derive(Clone, Copy)]
+#[allow(non_camel_case_types)]
+pub enum ReasonFlags {
+    unspecified = 0,
+    key_compromise = 1,
+    ca_compromise = 2,
+    affiliation_changed = 3,
+    superseded = 4,
+    cessation_of_operation = 5,
+    certificate_hold = 6,
+    privilege_withdrawn = 9,
+    aa_compromise = 10,
+    remove_from_crl = 8,
+}
+
+#[pyclass(module = "qh3._hazmat")]
+#[derive(Clone, Copy)]
+#[allow(non_camel_case_types)]
+pub enum OCSPResponseStatus {
+    SUCCESSFUL = 0,
+    MALFORMED_REQUEST = 1,
+    INTERNAL_ERROR = 2,
+    TRY_LATER = 3,
+    SIG_REQUIRED = 5,
+    UNAUTHORIZED = 6,
+}
+
+#[pyclass(module = "qh3._hazmat")]
+#[derive(Clone, Copy)]
+#[allow(non_camel_case_types)]
+pub enum OCSPCertStatus {
+    GOOD = 0,
+    REVOKED = 1,
+    UNKNOWN = 2,
+}
+
+
+#[pyclass(module = "qh3._hazmat")]
+#[allow(non_camel_case_types)]
+pub struct OCSPResponse {
+    next_update: u64,
+    response_status: OCSPResponseStatus,
+    certificate_status: OCSPCertStatus,
+    revocation_reason: Option<ReasonFlags>,
+}
+
+#[pymethods]
+impl OCSPResponse {
+    #[new]
+    pub fn py_new(raw_response: &PyBytes) -> PyResult<Self> {
+        let ocsp_res: OcspResponse = OcspResponse::from_der(&raw_response.as_bytes()).unwrap();
+
+        if !ocsp_res.response_bytes.is_some() {
+            return Err(PyValueError::new_err("OCSP Server did not provide answers"));
+        }
+
+        let inner_resp: BasicOcspResponse = BasicOcspResponse::from_der(&ocsp_res.response_bytes.unwrap().response.as_bytes()).unwrap();
+
+        if inner_resp.tbs_response_data.responses.len() == 0 {
+            return Err(PyValueError::new_err("OCSP Server did not provide answers"));
+        }
+
+        let first_resp_for_cert: &SingleResponse = &inner_resp.tbs_response_data.responses[0];
+
+        return Ok(
+            OCSPResponse {
+                next_update: first_resp_for_cert.next_update.unwrap().0.to_unix_duration().as_secs(),
+                response_status: match ocsp_res.response_status {
+                    InternalOcspResponseStatus::Successful => OCSPResponseStatus::SUCCESSFUL,
+                    InternalOcspResponseStatus::MalformedRequest => OCSPResponseStatus::MALFORMED_REQUEST,
+                    InternalOcspResponseStatus::InternalError => OCSPResponseStatus::INTERNAL_ERROR,
+                    InternalOcspResponseStatus::TryLater => OCSPResponseStatus::TRY_LATER,
+                    InternalOcspResponseStatus::SigRequired => OCSPResponseStatus::SIG_REQUIRED,
+                    InternalOcspResponseStatus::Unauthorized => OCSPResponseStatus::UNAUTHORIZED
+                },
+                certificate_status: match first_resp_for_cert.cert_status {
+                    InternalCertStatus::Good(..) => OCSPCertStatus::GOOD,
+                    InternalCertStatus::Revoked(_) => OCSPCertStatus::REVOKED,
+                    InternalCertStatus::Unknown(_) => OCSPCertStatus::UNKNOWN,
+                },
+                revocation_reason: match first_resp_for_cert.cert_status {
+                    InternalCertStatus::Revoked(info) => match info.revocation_reason {
+                        Some(reason) => match reason as u8 {
+                            0 => Some(ReasonFlags::unspecified),
+                            1 => Some(ReasonFlags::key_compromise),
+                            2 => Some(ReasonFlags::ca_compromise),
+                            3 => Some(ReasonFlags::affiliation_changed),
+                            4 => Some(ReasonFlags::superseded),
+                            5 => Some(ReasonFlags::cessation_of_operation),
+                            6 => Some(ReasonFlags::certificate_hold),
+                            8 => Some(ReasonFlags::remove_from_crl),
+                            9 => Some(ReasonFlags::privilege_withdrawn),
+                            10 => Some(ReasonFlags::aa_compromise),
+                            _ => None
+                        },
+                        _ => None
+                    },
+                    InternalCertStatus::Good(_) | InternalCertStatus::Unknown(_) => None
+                }
+            }
+        )
+    }
+
+    #[getter]
+    pub fn next_update(&self) -> u64 {
+        return self.next_update;
+    }
+
+    #[getter]
+    pub fn response_status(&self) -> OCSPResponseStatus {
+        return self.response_status;
+    }
+
+    #[getter]
+    pub fn certificate_status(&self) -> OCSPCertStatus {
+        return self.certificate_status;
+    }
+
+    #[getter]
+    pub fn revocation_reason(&self) -> Option<ReasonFlags> {
+        return self.revocation_reason;
+    }
+}
+
+
+#[pyclass(module = "qh3._hazmat")]
+pub struct OCSPRequest {
+    inner_request: Vec<u8>
+}
+
+#[pymethods]
+impl OCSPRequest {
+    #[new]
+    pub fn py_new(peer_certificate: &PyBytes, issuer_certificate: &PyBytes) -> PyResult<Self> {
+        let issuer = Certificate::from_der(&issuer_certificate.as_bytes()).unwrap();
+        let cert = Certificate::from_der(&peer_certificate.as_bytes()).unwrap();
+
+        let req: InternalOcspRequest = OcspRequestBuilder::default()
+            .with_request(Request::from_cert::<Sha1>(&issuer, &cert).unwrap())
+            .build();
+
+        return match req.to_der() {
+            Ok(raw_der) => Ok(
+                OCSPRequest {
+                    inner_request: raw_der
+                }
+            ),
+            Err(_) => Err(PyValueError::new_err("unable to generate the request"))
+        };
+    }
+
+    pub fn public_bytes<'a>(&self, py: Python<'a>) -> &'a PyBytes {
+        return PyBytes::new(
+            py,
+            &self.inner_request
+        );
+    }
+}


### PR DESCRIPTION
This make for cryptography removal and propose a viable way to issue OCSP requests and parse responses.
To be considered hazmat / private api.