### PR TITLE
:bug: Fix decryption error after receiving long (quic) header that required key derivation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+1.0.7 (2024-05-08)
+=====================
+
+**Fixed**
+- Decryption error after receiving long (quic) header that required key derivation.
+
 1.0.6 (2024-05-06)
 =====================
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "qh3"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "aes",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qh3"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3"

--- a/qh3/__init__.py
+++ b/qh3/__init__.py
@@ -11,7 +11,7 @@ from .quic.logger import QuicFileLogger, QuicLogger
 from .quic.packet import QuicProtocolVersion
 from .tls import CipherSuite, SessionTicket
 
-__version__ = "1.0.6"
+__version__ = "1.0.7"
 
 __all__ = (
     "connect",

--- a/qh3/quic/crypto.py
+++ b/qh3/quic/crypto.py
@@ -146,7 +146,9 @@ def next_key_phase(self: CryptoContext) -> CryptoContext:
     crypto = CryptoContext(key_phase=int(not self.key_phase))
     crypto.setup(
         cipher_suite=self.cipher_suite,
-        secret=hkdf_expand_label(algorithm, self.secret, b"quic ku", b"", algorithm),
+        secret=hkdf_expand_label(
+            algorithm, self.secret, b"quic ku", b"", int(algorithm / 8)
+        ),
         version=self.version,
     )
     return crypto


### PR DESCRIPTION
Report originally came from upstream Niquests.

Close https://github.com/jawah/niquests/issues/116