### PR TITLE
Fix: Negotiated protocol version should not be logged as info

### DIFF
--- a/qh3/quic/connection.py
+++ b/qh3/quic/connection.py
@@ -1167,7 +1167,7 @@ class QuicConnection:
                         ]
                         break
             self._version_negotiated_compatible = True
-            self._logger.info(
+            self._logger.debug(
                 "Negotiated protocol version %s", pretty_protocol_version(self._version)
             )
 


### PR DESCRIPTION
For me, as application user, using this library, it gives nothing.

```
INFO     [ba500503aec93bfa] Negotiated protocol version 0x00000001 (VERSION_1)
```

Refs
- https://github.com/Taxel/PlexTraktSync/pull/2081