### PR TITLE
Release 1.7.1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -538,7 +538,7 @@ jobs:
           PYO3_CROSS: 1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist -i 3.13t
+          args: --release --out dist -i ${{ matrix.python_version }}
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,16 @@
+1.7.1 (2026-03-30)
+====================
+
+**Fixed**
+- ls-qpack-rs strict enforcement struct assert at build time. (https://github.com/jawah/qh3/issues/105)
+
+**Changed**
+- Updated aws-lc-sys v0.39.0 to v0.39.1.
+- Updated ls-qpack-rs v0.3.0 to v0.3.1.
+
+**Misc**
+- Missing ARM64 pre-built wheel for Windows non freethreaded build. (https://github.com/jawah/qh3/issues/106)
+
 1.7.0 (2026-03-23)
 ====================
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ version = "0.13.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bce4948d2520386c6d92a6ea2d472300257702242e5a1d01d6add52bd2e7c1"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "cc",
  "cmake",
  "dunce",
@@ -94,11 +94,11 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "cc",
  "cmake",
  "dunce",
@@ -118,26 +118,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
 ]
 
 [[package]]
@@ -195,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -243,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -690,9 +670,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "ls-qpack-rs"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc8d4c5fdac4605bae648df97e25fa4febe6fd73f179cb40c1d84c3ad239aa74"
+checksum = "67ca13a214fd4d18efa614633fd38697117cb3728d131afadc2268e7f9f5e8e7"
 dependencies = [
  "libc",
  "ls-qpack-rs-sys",
@@ -700,11 +680,11 @@ dependencies = [
 
 [[package]]
 name = "ls-qpack-rs-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aa24f71119540e6dfe671981a0ebcb6e5376514cb451cc33c1e9cd925d69afd"
+checksum = "62575b97833935501a543e5bcc43af9fec5042015f15dcbc3c3aee6e47d7f205"
 dependencies = [
- "bindgen 0.71.1",
+ "bindgen",
  "cmake",
  "libc",
 ]
@@ -759,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -984,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "qh3"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "aws-lc-rs",
  "bincode",
@@ -1128,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -1638,18 +1618,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qh3"
-version = "1.7.0"
+version = "1.7.1"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"
@@ -14,7 +14,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.28.2", features = ["extension-module", "abi3-py37", "generate-import-lib"] }
-ls-qpack-rs = "0.3.0"
+ls-qpack-rs = "0.3.1"
 rustls = "0.23.25"
 x509-parser = "0.18.0"
 rsa = { version = "0.9.8", features = ["sha2", "pem", "getrandom"] }

--- a/qh3/__init__.py
+++ b/qh3/__init__.py
@@ -13,7 +13,7 @@ from .quic.logger import QuicFileLogger, QuicLogger
 from .quic.packet import QuicProtocolVersion
 from .tls import CipherSuite, SessionTicket
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 
 __all__ = (
     "connect",


### PR DESCRIPTION
1.7.1 (2026-03-30)
====================

**Fixed**
- ls-qpack-rs strict enforcement struct assert at build time. (https://github.com/jawah/qh3/issues/105)

**Changed**
- Updated aws-lc-sys v0.39.0 to v0.39.1.
- Updated ls-qpack-rs v0.3.0 to v0.3.1.

**Misc**
- Missing ARM64 pre-built wheel for Windows non freethreaded build. (https://github.com/jawah/qh3/issues/106)
