### PR TITLE
Release 1.7.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,17 @@
+1.7.2 (2026-04-20)
+==================
+
+**Fixed**
+- HTTP/3 ``SETTINGS_H3_DATAGRAM`` identifier now uses the RFC 9297 value ``0x33``
+  instead of the obsolete draft ietf masque value ``0xFFD277``.
+  This fixes interop with RFC 9297-compliant peers. The legacy identifier is still
+  accepted on receive for backward compatibility. (https://github.com/jawah/qh3/issues/107)
+
+**Changed**
+- Updated aws-lc-rs v1.16.2 to v1.16.3
+- Updated pyo3 v0.28.2 to v0.28.3
+- Updated rustls v0.23.37 to v0.23.3
+
 1.7.1 (2026-03-30)
 ====================
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.13"
+version = "0.13.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bce4948d2520386c6d92a6ea2d472300257702242e5a1d01d6add52bd2e7c1"
+checksum = "d3d619165468401dec3caa3366ebffbcb83f2f31883e5b3932f8e2dec2ddc568"
 dependencies = [
  "bindgen",
  "cc",
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "bindgen",
  "cc",
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -490,12 +490,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -503,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -516,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -530,15 +531,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -550,15 +551,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -636,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -658,9 +659,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
@@ -853,9 +854,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -896,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
  "libc",
  "once_cell",
@@ -910,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "python3-dll-a",
  "target-lexicon",
@@ -920,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -930,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -942,9 +943,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -955,16 +956,16 @@ dependencies = [
 
 [[package]]
 name = "python3-dll-a"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d381ef313ae70b4da5f95f8a4de773c6aa5cd28f73adec4b4a31df70b66780d8"
+checksum = "d80ba7540edb18890d444c5aa8e1f1f99b1bdf26fb26ae383135325f4a36042b"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "qh3"
-version = "1.7.1"
+version = "1.7.2"
 dependencies = [
  "aws-lc-rs",
  "bincode",
@@ -1132,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -1165,9 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1197,9 +1198,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1384,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1415,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-ident"
@@ -1451,9 +1452,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen",
 ]
@@ -1539,15 +1540,15 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "x509-cert"
@@ -1595,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -1606,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1638,18 +1639,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1679,9 +1680,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -1690,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -1701,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qh3"
-version = "1.7.1"
+version = "1.7.2"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"

--- a/qh3/__init__.py
+++ b/qh3/__init__.py
@@ -13,7 +13,7 @@ from .quic.logger import QuicFileLogger, QuicLogger
 from .quic.packet import QuicProtocolVersion
 from .tls import CipherSuite, SessionTicket
 
-__version__ = "1.7.1"
+__version__ = "1.7.2"
 
 __all__ = (
     "connect",

--- a/qh3/h3/connection.py
+++ b/qh3/h3/connection.py
@@ -682,7 +682,7 @@ class H3Connection:
 
         if frame_type == FrameType.DATA:
             # check DATA frame is allowed
-            if stream.headers_recv_state != HeadersState.AFTER_HEADERS:
+            if stream.headers_recv_state is not HeadersState.AFTER_HEADERS:
                 raise FrameUnexpected("DATA frame is not allowed in this state")
 
             if stream_ended or frame_data:
@@ -696,7 +696,7 @@ class H3Connection:
                 )
         elif frame_type == FrameType.HEADERS:
             # check HEADERS frame is allowed
-            if stream.headers_recv_state == HeadersState.AFTER_TRAILERS:
+            if stream.headers_recv_state is HeadersState.AFTER_TRAILERS:
                 raise FrameUnexpected("HEADERS frame is not allowed in this state")
 
             # try to decode HEADERS, may raise pylsqpack.StreamBlocked
@@ -705,7 +705,7 @@ class H3Connection:
             status_code: int | None = None
 
             # validate headers
-            if stream.headers_recv_state == HeadersState.INITIAL:
+            if stream.headers_recv_state is HeadersState.INITIAL:
                 if self._is_client:
                     status_code = validate_response_headers(headers)
                 else:
@@ -730,7 +730,7 @@ class H3Connection:
                 )
 
             # update state and emit headers
-            if stream.headers_recv_state == HeadersState.INITIAL:
+            if stream.headers_recv_state is HeadersState.INITIAL:
                 # Informational Response MUST be taken as-is without
                 # skipping the main response.
                 if status_code is None or status_code >= 200 or stream_ended:
@@ -739,7 +739,7 @@ class H3Connection:
                 stream.headers_recv_state = HeadersState.AFTER_TRAILERS
 
             if (
-                stream.headers_recv_state == HeadersState.INITIAL
+                stream.headers_recv_state is HeadersState.INITIAL
                 and status_code is not None
                 and status_code < 200
             ):

--- a/qh3/h3/connection.py
+++ b/qh3/h3/connection.py
@@ -1212,16 +1212,10 @@ class H3Connection:
         if h3_datagram is None:
             h3_datagram = settings.get(Setting.H3_DATAGRAM_DRAFT05)
 
-        if (
-            h3_datagram == 1
-            and self._quic._remote_max_datagram_frame_size is None
-        ):
+        if h3_datagram == 1 and self._quic._remote_max_datagram_frame_size is None:
             raise SettingsError(
                 "H3_DATAGRAM requires max_datagram_frame_size transport parameter"
             )
 
-        if (
-            settings.get(Setting.ENABLE_WEBTRANSPORT) == 1
-            and h3_datagram != 1
-        ):
+        if settings.get(Setting.ENABLE_WEBTRANSPORT) == 1 and h3_datagram != 1:
             raise SettingsError("ENABLE_WEBTRANSPORT requires H3_DATAGRAM")

--- a/qh3/h3/connection.py
+++ b/qh3/h3/connection.py
@@ -41,6 +41,7 @@ UPPERCASE = re.compile(b"[A-Z]")
 
 
 class ErrorCode(IntEnum):
+    H3_DATAGRAM_ERROR = 0x33
     H3_NO_ERROR = 0x100
     H3_GENERAL_PROTOCOL_ERROR = 0x101
     H3_INTERNAL_ERROR = 0x102
@@ -89,8 +90,11 @@ class Setting(IntEnum):
 
     # https://datatracker.ietf.org/doc/html/rfc9220#section-5
     ENABLE_CONNECT_PROTOCOL = 0x8
-    # https://datatracker.ietf.org/doc/html/draft-ietf-masque-h3-datagram-05#section-9.1
-    H3_DATAGRAM = 0xFFD277
+    # https://datatracker.ietf.org/doc/html/rfc9297#section-2.1.1
+    H3_DATAGRAM = 0x33
+    # Legacy identifier from draft-ietf-masque-h3-datagram-05; kept so we can
+    # interop on receive with peers that have not migrated to RFC 9297.
+    H3_DATAGRAM_DRAFT05 = 0xFFD277
     # https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http2-02#section-10.1
     ENABLE_WEBTRANSPORT = 0x2B603742
 
@@ -1196,12 +1200,20 @@ class H3Connection:
             Setting.ENABLE_CONNECT_PROTOCOL,
             Setting.ENABLE_WEBTRANSPORT,
             Setting.H3_DATAGRAM,
+            Setting.H3_DATAGRAM_DRAFT05,
         ]:
             if setting in settings and settings[setting] not in (0, 1):
                 raise SettingsError(f"{setting.name} setting must be 0 or 1")
 
+        # Accept either the RFC 9297 identifier (0x33) or the legacy
+        # draft-ietf-masque-h3-datagram-05 identifier (0xFFD277) on receive,
+        # so we can interop with peers that have not yet migrated.
+        h3_datagram = settings.get(Setting.H3_DATAGRAM)
+        if h3_datagram is None:
+            h3_datagram = settings.get(Setting.H3_DATAGRAM_DRAFT05)
+
         if (
-            settings.get(Setting.H3_DATAGRAM) == 1
+            h3_datagram == 1
             and self._quic._remote_max_datagram_frame_size is None
         ):
             raise SettingsError(
@@ -1210,6 +1222,6 @@ class H3Connection:
 
         if (
             settings.get(Setting.ENABLE_WEBTRANSPORT) == 1
-            and settings.get(Setting.H3_DATAGRAM) != 1
+            and h3_datagram != 1
         ):
             raise SettingsError("ENABLE_WEBTRANSPORT requires H3_DATAGRAM")

--- a/src/aead.rs
+++ b/src/aead.rs
@@ -25,7 +25,7 @@ impl QuicNonce {
     ///
     /// This is `iv ^ seq` where `seq` is encoded as a 96-bit big-endian integer.
     #[inline]
-    pub fn new(iv: &[u8], seq: u64) -> Self {
+    pub fn new(iv: &[u8; NONCE_LEN], seq: u64) -> Self {
         let mut nonce = Self([0u8; NONCE_LEN]);
         put_u64(seq, &mut nonce.0[4..]);
 
@@ -37,22 +37,33 @@ impl QuicNonce {
     }
 }
 
+#[inline]
+fn iv_from_pybytes(iv: &Bound<'_, PyBytes>) -> PyResult<[u8; NONCE_LEN]> {
+    let bytes = iv.as_bytes();
+    if bytes.len() != NONCE_LEN {
+        return Err(CryptoError::new_err("Invalid iv length"));
+    }
+    let mut out = [0u8; NONCE_LEN];
+    out.copy_from_slice(bytes);
+    Ok(out)
+}
+
 #[pyclass(name = "AeadChaCha20Poly1305", module = "qh3._hazmat")]
 pub struct AeadChaCha20Poly1305 {
     key: LessSafeKey,
-    iv: Vec<u8>,
+    iv: [u8; NONCE_LEN],
 }
 
 #[pyclass(name = "AeadAes256Gcm", module = "qh3._hazmat")]
 pub struct AeadAes256Gcm {
     key: LessSafeKey,
-    iv: Vec<u8>,
+    iv: [u8; NONCE_LEN],
 }
 
 #[pyclass(name = "AeadAes128Gcm", module = "qh3._hazmat")]
 pub struct AeadAes128Gcm {
     key: LessSafeKey,
-    iv: Vec<u8>,
+    iv: [u8; NONCE_LEN],
 }
 
 #[pymethods]
@@ -64,15 +75,11 @@ impl AeadAes256Gcm {
             Err(_) => return Err(CryptoError::new_err("Invalid AEAD key")),
         };
 
-        let iv_as_vec = iv.as_bytes().to_vec();
-
-        if iv_as_vec.len() != NONCE_LEN {
-            return Err(CryptoError::new_err("Invalid iv length"));
-        }
+        let iv = iv_from_pybytes(&iv)?;
 
         Ok(AeadAes256Gcm {
             key: LessSafeKey::new(unbound),
-            iv: iv_as_vec,
+            iv,
         })
     }
 
@@ -90,7 +97,7 @@ impl AeadAes256Gcm {
 
         let res = py.detach(|| {
             self.key.open_in_place(
-                Nonce::assume_unique_for_key(QuicNonce::new(self.iv.as_ref(), packet_number).0),
+                Nonce::assume_unique_for_key(QuicNonce::new(&self.iv, packet_number).0),
                 aad,
                 &mut in_out_buffer,
             )
@@ -109,22 +116,31 @@ impl AeadAes256Gcm {
         data: Bound<'_, PyBytes>,
         associated_data: Bound<'_, PyBytes>,
     ) -> PyResult<Bound<'a, PyBytes>> {
-        let mut in_out_buffer = Vec::from(data.as_bytes());
+        let plaintext = data.as_bytes();
+        let plaintext_len = plaintext.len();
+        let tag_len = AES_256_GCM.tag_len();
 
-        let aad = Aad::from(associated_data.as_bytes());
+        let aad_bytes = associated_data.as_bytes();
+        let nonce = QuicNonce::new(&self.iv, packet_number).0;
 
-        let res = py.detach(|| {
-            self.key.seal_in_place_append_tag(
-                Nonce::assume_unique_for_key(QuicNonce::new(self.iv.as_ref(), packet_number).0),
-                aad,
-                &mut in_out_buffer,
-            )
-        });
-
-        match res {
-            Ok(_) => Ok(PyBytes::new(py, &in_out_buffer)),
-            Err(_) => Err(CryptoError::new_err("encryption failed")),
-        }
+        PyBytes::new_with(py, plaintext_len + tag_len, |buffer| {
+            buffer[..plaintext_len].copy_from_slice(plaintext);
+            let aad = Aad::from(aad_bytes);
+            let res = py.detach(|| {
+                self.key.seal_in_place_separate_tag(
+                    Nonce::assume_unique_for_key(nonce),
+                    aad,
+                    &mut buffer[..plaintext_len],
+                )
+            });
+            match res {
+                Ok(tag) => {
+                    buffer[plaintext_len..].copy_from_slice(tag.as_ref());
+                    Ok(())
+                }
+                Err(_) => Err(CryptoError::new_err("encryption failed")),
+            }
+        })
     }
 }
 
@@ -137,15 +153,11 @@ impl AeadAes128Gcm {
             Err(_) => return Err(CryptoError::new_err("Invalid AEAD key")),
         };
 
-        let iv_as_vec = iv.as_bytes().to_vec();
-
-        if iv_as_vec.len() != NONCE_LEN {
-            return Err(CryptoError::new_err("Invalid iv length"));
-        }
+        let iv = iv_from_pybytes(&iv)?;
 
         Ok(AeadAes128Gcm {
             key: LessSafeKey::new(unbound),
-            iv: iv_as_vec,
+            iv,
         })
     }
 
@@ -163,7 +175,7 @@ impl AeadAes128Gcm {
 
         let res = py.detach(|| {
             self.key.open_in_place(
-                Nonce::assume_unique_for_key(QuicNonce::new(self.iv.as_ref(), packet_number).0),
+                Nonce::assume_unique_for_key(QuicNonce::new(&self.iv, packet_number).0),
                 aad,
                 &mut in_out_buffer,
             )
@@ -182,22 +194,31 @@ impl AeadAes128Gcm {
         data: Bound<'_, PyBytes>,
         associated_data: Bound<'_, PyBytes>,
     ) -> PyResult<Bound<'a, PyBytes>> {
-        let mut in_out_buffer = Vec::from(data.as_bytes());
+        let plaintext = data.as_bytes();
+        let plaintext_len = plaintext.len();
+        let tag_len = AES_128_GCM.tag_len();
 
-        let aad = Aad::from(associated_data.as_bytes());
+        let aad_bytes = associated_data.as_bytes();
+        let nonce = QuicNonce::new(&self.iv, packet_number).0;
 
-        let res = py.detach(|| {
-            self.key.seal_in_place_append_tag(
-                Nonce::assume_unique_for_key(QuicNonce::new(self.iv.as_ref(), packet_number).0),
-                aad,
-                &mut in_out_buffer,
-            )
-        });
-
-        match res {
-            Ok(_) => Ok(PyBytes::new(py, &in_out_buffer)),
-            Err(_) => Err(CryptoError::new_err("encryption failed")),
-        }
+        PyBytes::new_with(py, plaintext_len + tag_len, |buffer| {
+            buffer[..plaintext_len].copy_from_slice(plaintext);
+            let aad = Aad::from(aad_bytes);
+            let res = py.detach(|| {
+                self.key.seal_in_place_separate_tag(
+                    Nonce::assume_unique_for_key(nonce),
+                    aad,
+                    &mut buffer[..plaintext_len],
+                )
+            });
+            match res {
+                Ok(tag) => {
+                    buffer[plaintext_len..].copy_from_slice(tag.as_ref());
+                    Ok(())
+                }
+                Err(_) => Err(CryptoError::new_err("encryption failed")),
+            }
+        })
     }
 
     pub fn encrypt_with_nonce<'a>(
@@ -207,23 +228,31 @@ impl AeadAes128Gcm {
         data: Bound<'_, PyBytes>,
         associated_data: Bound<'_, PyBytes>,
     ) -> PyResult<Bound<'a, PyBytes>> {
-        let mut in_out_buffer = Vec::from(data.as_bytes());
+        let plaintext = data.as_bytes();
+        let plaintext_len = plaintext.len();
+        let tag_len = AES_128_GCM.tag_len();
 
-        let aad = Aad::from(associated_data.as_bytes());
-        let nonce_as_ref = nonce.as_bytes();
+        let aad_bytes = associated_data.as_bytes();
+        let nonce_bytes = nonce.as_bytes();
 
-        let res = py.detach(|| {
-            self.key.seal_in_place_append_tag(
-                Nonce::try_assume_unique_for_key(nonce_as_ref).unwrap(),
-                aad,
-                &mut in_out_buffer,
-            )
-        });
-
-        match res {
-            Ok(_) => Ok(PyBytes::new(py, &in_out_buffer)),
-            Err(_) => Err(CryptoError::new_err("encryption failed")),
-        }
+        PyBytes::new_with(py, plaintext_len + tag_len, |buffer| {
+            buffer[..plaintext_len].copy_from_slice(plaintext);
+            let aad = Aad::from(aad_bytes);
+            let res = py.detach(|| {
+                self.key.seal_in_place_separate_tag(
+                    Nonce::try_assume_unique_for_key(nonce_bytes).unwrap(),
+                    aad,
+                    &mut buffer[..plaintext_len],
+                )
+            });
+            match res {
+                Ok(tag) => {
+                    buffer[plaintext_len..].copy_from_slice(tag.as_ref());
+                    Ok(())
+                }
+                Err(_) => Err(CryptoError::new_err("encryption failed")),
+            }
+        })
     }
 }
 
@@ -231,15 +260,11 @@ impl AeadAes128Gcm {
 impl AeadChaCha20Poly1305 {
     #[new]
     pub fn py_new(key: Bound<'_, PyBytes>, iv: Bound<'_, PyBytes>) -> PyResult<Self> {
-        let iv_as_vec = iv.as_bytes().to_vec();
-
-        if iv_as_vec.len() != NONCE_LEN {
-            return Err(CryptoError::new_err("Invalid iv length"));
-        }
+        let iv = iv_from_pybytes(&iv)?;
 
         Ok(AeadChaCha20Poly1305 {
             key: LessSafeKey::new(UnboundKey::new(&CHACHA20_POLY1305, key.as_bytes()).unwrap()),
-            iv: iv_as_vec,
+            iv,
         })
     }
 
@@ -257,7 +282,7 @@ impl AeadChaCha20Poly1305 {
 
         let res = py.detach(|| {
             self.key.open_in_place(
-                Nonce::assume_unique_for_key(QuicNonce::new(self.iv.as_ref(), packet_number).0),
+                Nonce::assume_unique_for_key(QuicNonce::new(&self.iv, packet_number).0),
                 aad,
                 &mut in_out_buffer,
             )
@@ -276,21 +301,30 @@ impl AeadChaCha20Poly1305 {
         data: Bound<'_, PyBytes>,
         associated_data: Bound<'_, PyBytes>,
     ) -> PyResult<Bound<'a, PyBytes>> {
-        let mut in_out_buffer = Vec::from(data.as_bytes());
+        let plaintext = data.as_bytes();
+        let plaintext_len = plaintext.len();
+        let tag_len = CHACHA20_POLY1305.tag_len();
 
-        let aad = Aad::from(associated_data.as_bytes());
+        let aad_bytes = associated_data.as_bytes();
+        let nonce = QuicNonce::new(&self.iv, packet_number).0;
 
-        let res = py.detach(|| {
-            self.key.seal_in_place_append_tag(
-                Nonce::assume_unique_for_key(QuicNonce::new(self.iv.as_ref(), packet_number).0),
-                aad,
-                &mut in_out_buffer,
-            )
-        });
-
-        match res {
-            Ok(_) => Ok(PyBytes::new(py, &in_out_buffer)),
-            Err(_) => Err(CryptoError::new_err("encryption failed")),
-        }
+        PyBytes::new_with(py, plaintext_len + tag_len, |buffer| {
+            buffer[..plaintext_len].copy_from_slice(plaintext);
+            let aad = Aad::from(aad_bytes);
+            let res = py.detach(|| {
+                self.key.seal_in_place_separate_tag(
+                    Nonce::assume_unique_for_key(nonce),
+                    aad,
+                    &mut buffer[..plaintext_len],
+                )
+            });
+            match res {
+                Ok(tag) => {
+                    buffer[plaintext_len..].copy_from_slice(tag.as_ref());
+                    Ok(())
+                }
+                Err(_) => Err(CryptoError::new_err("encryption failed")),
+            }
+        })
     }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -146,14 +146,12 @@ impl Buffer {
             return Err(BufferReadError::new_err("Read out of bounds"));
         }
 
-        let tmp = vec![
+        let extract = u32::from_be_bytes([
             0,
             self.data[self.pos],
             self.data[self.pos + 1],
             self.data[self.pos + 2],
-        ];
-
-        let extract = u32::from_be_bytes(tmp.try_into().unwrap());
+        ]);
         self.pos = end_offset;
 
         Ok(extract)

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -71,7 +71,7 @@ impl QpackEncoder {
         stream_id: u64,
         headers: Vec<(Bound<'_, PyBytes>, Bound<'_, PyBytes>)>,
     ) -> PyResult<Bound<'a, PyTuple>> {
-        let mut decoded_vec: Vec<(&str, &str)> = Vec::new();
+        let mut decoded_vec: Vec<(&str, &str)> = Vec::with_capacity(headers.len());
 
         for (header, value) in headers.iter() {
             let header_str = std::str::from_utf8(header.as_bytes()).map_err(|e| {
@@ -192,9 +192,14 @@ impl QpackDecoder {
 
         match res {
             Ok(DecoderOutput::Done(ref buffer)) => {
-                let decoded_headers = PyList::new(py, Vec::<(String, String)>::new()).unwrap();
+                let headers_iter = buffer.headers();
+                let decoded_headers = PyList::new(
+                    py,
+                    Vec::<(String, String)>::with_capacity(headers_iter.len()),
+                )
+                .unwrap();
 
-                for header in buffer.headers() {
+                for header in headers_iter {
                     let _ = decoded_headers.append(
                         PyTuple::new(
                             py,

--- a/tests/test_h3.py
+++ b/tests/test_h3.py
@@ -1519,6 +1519,51 @@ class TestH3Connection:
                 "H3_DATAGRAM requires max_datagram_frame_size transport parameter",
             )
 
+    def test_validate_settings_h3_datagram_draft05_legacy_accepted(self):
+        # A peer still sending the obsolete draft-ietf-masque-h3-datagram-05
+        # identifier (0xFFD277) instead of the RFC 9297 value (0x33) must be
+        # interop-accepted; the validator should treat it equivalently.
+        quic_server = FakeQuicConnection(
+            configuration=QuicConfiguration(is_client=False)
+        )
+        quic_server._remote_max_datagram_frame_size = 65536
+        h3_server = H3Connection(quic_server)
+
+        settings = copy.copy(DUMMY_SETTINGS)
+        settings[Setting.H3_DATAGRAM_DRAFT05] = 1
+        h3_server.handle_event(
+            StreamDataReceived(
+                stream_id=2,
+                data=encode_uint_var(StreamType.CONTROL)
+                + encode_frame(FrameType.SETTINGS, encode_settings(settings)),
+                end_stream=False,
+            )
+        )
+        # No connection close on a valid legacy H3_DATAGRAM=1 setting.
+        assert quic_server.closed is None
+
+    def test_validate_settings_h3_datagram_draft05_invalid_value(self):
+        quic_server = FakeQuicConnection(
+            configuration=QuicConfiguration(is_client=False)
+        )
+        h3_server = H3Connection(quic_server)
+
+        settings = copy.copy(DUMMY_SETTINGS)
+        settings[Setting.H3_DATAGRAM_DRAFT05] = 2
+        h3_server.handle_event(
+            StreamDataReceived(
+                stream_id=2,
+                data=encode_uint_var(StreamType.CONTROL)
+                + encode_frame(FrameType.SETTINGS, encode_settings(settings)),
+                end_stream=False,
+            )
+        )
+        assert quic_server.closed == \
+            (
+                ErrorCode.H3_SETTINGS_ERROR,
+                "H3_DATAGRAM_DRAFT05 setting must be 0 or 1",
+            )
+
     def test_validate_settings_enable_connect_protocol_invalid_value(self):
         quic_server = FakeQuicConnection(
             configuration=QuicConfiguration(is_client=False)


### PR DESCRIPTION
1.7.2 (2026-04-20)
==================

**Fixed**
- HTTP/3 ``SETTINGS_H3_DATAGRAM`` identifier now uses the RFC 9297 value ``0x33``
  instead of the obsolete draft ietf masque value ``0xFFD277``.
  This fixes interop with RFC 9297-compliant peers. The legacy identifier is still
  accepted on receive for backward compatibility. (https://github.com/jawah/qh3/issues/107)

**Changed**
- Updated aws-lc-rs v1.16.2 to v1.16.3
- Updated pyo3 v0.28.2 to v0.28.3
- Updated rustls v0.23.37 to v0.23.3
