### PR TITLE
Release 1.7.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+1.7.4 (2026-04-28)
+==================
+
+**Fixed**
+- Unexpected crash when a corrupted datagram is fed into the QUIC state machine.
+
+**Changed**
+- Updated rustls v0.23.38 to v0.23.39
+
 1.7.3 (2026-04-22)
 ==================
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -583,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -637,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "qh3"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "aws-lc-rs",
  "bincode",
@@ -1133,9 +1133,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -1157,9 +1157,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qh3"
-version = "1.7.3"
+version = "1.7.4"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"

--- a/qh3/__init__.py
+++ b/qh3/__init__.py
@@ -13,7 +13,7 @@ from .quic.logger import QuicFileLogger, QuicLogger
 from .quic.packet import QuicProtocolVersion
 from .tls import CipherSuite, SessionTicket
 
-__version__ = "1.7.3"
+__version__ = "1.7.4"
 
 __all__ = (
     "connect",

--- a/src/hpk.rs
+++ b/src/hpk.rs
@@ -81,6 +81,12 @@ impl QUICHeaderProtection {
     ) -> PyResult<(Bound<'a, PyBytes>, u32)> {
         let sample_offset = pn_offset + PACKET_NUMBER_LENGTH_MAX;
 
+        if packet.len() < sample_offset + SAMPLE_LENGTH {
+            return Err(CryptoError::new_err(
+                "Packet too short for header protection removal",
+            ));
+        }
+
         let mask = self
             .hpk
             .new_mask(&packet[sample_offset..sample_offset + SAMPLE_LENGTH])

--- a/tests/test_crypto_v1.py
+++ b/tests/test_crypto_v1.py
@@ -408,3 +408,20 @@ class TestCrypto:
         with pytest.raises(CryptoError) as cm:
             self.create_hp(key=bytes(33))
         assert str(cm.value) == "Given key is not valid for chosen algorithm"
+
+    def test_decrypt_short_server_packet_too_short(self):
+        """Truncated packet must raise CryptoError, not panic."""
+        pair = CryptoPair()
+        pair.recv.setup(
+            cipher_suite=INITIAL_CIPHER_SUITE,
+            secret=binascii.unhexlify(
+                "310281977cb8c1c1c1212d784b2d29e5a6489e23de848d370a5a2f9537f3a100"
+            ),
+            version=PROTOCOL_VERSION,
+        )
+
+        # encrypted_offset=9 requires at least 9+4+16=29 bytes for HP sample.
+        # Truncate to 27 bytes to reproduce the exact scenario from the bug.
+        truncated = SHORT_SERVER_ENCRYPTED_PACKET[:27]
+        with pytest.raises(CryptoError):
+            pair.decrypt_packet(truncated, 9, 0)

--- a/tests/test_ech.py
+++ b/tests/test_ech.py
@@ -24,7 +24,7 @@ _PROBE_TIMEOUT_S = 2
 # "cloudflare-ech.com". This gives us a real test where:
 #   - outer (cleartext) SNI  = cloudflare-ech.com   (public_name from ECHConfig)
 #   - inner (encrypted) SNI  = research.cloudflare.com  (the actual target)
-_ECH_HOST = "research.cloudflare.com"
+_ECH_HOST = "encryptedsni.com"
 _ECH_PORT = 443
 
 
@@ -127,11 +127,11 @@ async def test_ech_accepted(requires_network):
             elif isinstance(event, DataReceived):
                 body += event.data
 
-        assert headers[b":status"] == b"200"
+        assert headers[b":status"] == b"301"
 
         html = body.decode()
 
-        assert "<title>Cloudflare Research</title>" in html
+        assert not html
 
 
 @pytest.mark.asyncio
@@ -161,7 +161,7 @@ async def test_grease_ech_no_rejection(requires_network):
             elif isinstance(event, DataReceived):
                 body += event.data
 
-        assert headers[b":status"] == b"200"
+        assert headers[b":status"] == b"301"
         html = body.decode()
 
-        assert "<title>Cloudflare Research</title>" in html
+        assert not html


### PR DESCRIPTION
1.7.4 (2026-04-28)
==================

**Fixed**
- Unexpected crash when a corrupted datagram is fed into the QUIC state machine.

**Changed**
- Updated rustls v0.23.38 to v0.23.39
