### PR TITLE
Release 1.8.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@
   - fix(h3): surface StreamReset / StopSending events; enforce critical stream closure
   - fix(packet): reject duplicate transport parameters
   - fix(recovery): implement missing HyStart++
+  - fix(recovery): MTU probe through ping frame mistaken as real loss
   - chore: raise initial_rtt default to 333 ms
 
 1.8.0 (2026-05-03)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,17 @@
+1.8.1 (2026-05-07)
+==================
+
+**Fixed**
+- Remediation on various QUIC compliance items (enabled by 3rd party audit).
+  - fix(recovery): compliance batch
+  - fix(crypto): retain previous recv keys for 3 PTO
+  - fix(connection): stateless reset, CONNECTION_CLOSE retransmit, idle-timer floor
+  - fix(stream): FINAL_SIZE_ERROR, send-only stream cleanup
+  - fix(h3): surface StreamReset / StopSending events; enforce critical stream closure
+  - fix(packet): reject duplicate transport parameters
+  - fix(recovery): implement missing HyStart++
+  - chore: raise initial_rtt default to 333 ms
+
 1.8.0 (2026-05-03)
 ==================
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -977,7 +977,7 @@ dependencies = [
 
 [[package]]
 name = "qh3"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
  "aws-lc-rs",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qh3"
-version = "1.8.0"
+version = "1.8.1"
 edition = "2021"
 rust-version = "1.75"
 license = "BSD-3-Clause"

--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,7 @@ Features
 - OCSP Stapling (Client Only)
 - Encrypted Client Hello conforming with `RFC 9849`_
 - GRO/GSO support when available (Linux native and MacOS private batching API)
+- HyStart++ `RFC 9406`_
 
 Requirements
 ------------
@@ -95,5 +96,6 @@ License
 .. _RFC 9114: https://datatracker.ietf.org/doc/html/rfc9114
 .. _RFC 9369: https://datatracker.ietf.org/doc/html/rfc9369
 .. _RFC 9849: https://datatracker.ietf.org/doc/html/rfc9849
+.. _RFC 9406: https://datatracker.ietf.org/doc/html/rfc9406
 .. _niquests: https://github.com/jawah/niquests
 .. _urllib3.future: https://github.com/jawah/urllib3.future

--- a/qh3/__init__.py
+++ b/qh3/__init__.py
@@ -13,7 +13,7 @@ from .quic.logger import QuicFileLogger, QuicLogger
 from .quic.packet import QuicProtocolVersion
 from .tls import CipherSuite, SessionTicket
 
-__version__ = "1.8.0"
+__version__ = "1.8.1"
 
 __all__ = (
     "connect",

--- a/qh3/asyncio/protocol.py
+++ b/qh3/asyncio/protocol.py
@@ -182,6 +182,28 @@ class QuicConnectionProtocol(asyncio.DatagramProtocol):
             reader.feed_data(event.data)
             if event.end_stream:
                 reader.feed_eof()
+        elif isinstance(event, events.StreamReset):
+            # RFC 9000 3.5: peer abruptly terminated the stream. Surface
+            # this to any waiting reader as an exception/EOF so that
+            # callers do not hang forever waiting for data that will
+            # never arrive.
+            reader = self._stream_readers.get(event.stream_id, None)
+            if reader is not None:
+                reader.set_exception(
+                    ConnectionResetError(
+                        f"Stream {event.stream_id} reset by peer "
+                        f"(error code {event.error_code})"
+                    )
+                )
+                self._stream_readers.pop(event.stream_id, None)
+        elif isinstance(event, events.StopSendingReceived):
+            # RFC 9000 3.5: peer asked us to stop sending. Drop the
+            # reader so we no longer wait on it; the writer side is
+            # already torn down by the QUIC layer.
+            reader = self._stream_readers.get(event.stream_id, None)
+            if reader is not None:
+                reader.feed_eof()
+                self._stream_readers.pop(event.stream_id, None)
 
     # private
 

--- a/qh3/asyncio/protocol.py
+++ b/qh3/asyncio/protocol.py
@@ -293,7 +293,19 @@ class QuicStreamAdapter(asyncio.Transport):
         if self._closing:
             return
         self._closing = True
-        self.protocol._quic.send_stream_data(self.stream_id, b"", end_stream=True)
+        stream = self.protocol._quic._streams.get(self.stream_id)
+        if stream is None:
+            return
+        sender = stream.sender
+        if sender.is_finished or sender.reset_pending:
+            return
+        try:
+            self.protocol._quic.send_stream_data(self.stream_id, b"", end_stream=True)
+        except (
+            AssertionError,
+            KeyError,
+        ):  # Defensive: Lost a race with peer reset / connection teardown.
+            return
         self.protocol._transmit_soon()
 
     def close(self) -> None:

--- a/qh3/h3/connection.py
+++ b/qh3/h3/connection.py
@@ -16,7 +16,13 @@ from .._hazmat import (
     encode_uint_var,
 )
 from ..quic.connection import QuicConnection, stream_is_unidirectional
-from ..quic.events import DatagramFrameReceived, QuicEvent, StreamDataReceived
+from ..quic.events import (
+    DatagramFrameReceived,
+    QuicEvent,
+    StopSendingReceived,
+    StreamDataReceived,
+    StreamReset,
+)
 from ..quic.logger import QuicLoggerTrace
 from .events import (
     DatagramReceived,
@@ -28,6 +34,12 @@ from .events import (
     InformationalHeadersReceived,
     PushPromiseReceived,
     WebTransportStreamDataReceived,
+)
+from .events import (
+    StopSending as H3StopSending,
+)
+from .events import (
+    StreamReset as H3StreamReset,
 )
 from .exceptions import NoAvailablePushIDError
 
@@ -307,9 +319,7 @@ def validate_response_headers(headers: Headers) -> int | None:
     try:
         return int(status_code)
     except ValueError:
-        raise MessageError(
-            f"Invalid :status value {status_code!r}"
-        ) from None
+        raise MessageError(f"Invalid :status value {status_code!r}") from None
 
 
 def validate_trailers(headers: Headers) -> None:
@@ -427,6 +437,10 @@ class H3Connection:
                     return self._receive_stream_data(event)
                 elif isinstance(event, DatagramFrameReceived):
                     return self._receive_datagram(event.data)
+                elif isinstance(event, StreamReset):
+                    return self._receive_stream_reset(event.stream_id, event.error_code)
+                elif isinstance(event, StopSendingReceived):
+                    return self._receive_stop_sending(event.stream_id, event.error_code)
             except ProtocolError as exc:
                 self._is_done = True
                 self._quic.close(
@@ -434,6 +448,62 @@ class H3Connection:
                 )
 
         return []
+
+    def _is_critical_stream(self, stream_id: int) -> bool:
+        """
+        RFC 9114 6.2: control, QPACK encoder, and QPACK decoder streams are
+        critical streams. Closure of any critical stream MUST be treated as
+        a connection error of type H3_CLOSED_CRITICAL_STREAM.
+        """
+        return stream_id in (
+            self._peer_control_stream_id,
+            self._peer_decoder_stream_id,
+            self._peer_encoder_stream_id,
+            self._local_control_stream_id,
+            self._local_decoder_stream_id,
+            self._local_encoder_stream_id,
+        )
+
+    def _receive_stream_reset(self, stream_id: int, error_code: int) -> list[H3Event]:
+        # RFC 9114 6.2.1: a peer-initiated reset of a critical stream is a
+        # connection error of type H3_CLOSED_CRITICAL_STREAM.
+        if self._is_critical_stream(stream_id):
+            raise ClosedCriticalStream(f"Critical stream {stream_id} reset by peer")
+
+        stream = self._stream.get(stream_id)
+        if stream is None:
+            return [H3StreamReset(stream_id=stream_id, error_code=error_code)]
+
+        # Drop the stream so it cannot accumulate further state and so any
+        # future cleanup (e.g. waiting on receiving_ended) is satisfied.
+        # Note: RFC 9204 2.2.2.2 Stream Cancellation is OPTIONAL and is
+        # only useful when the encoder uses the dynamic table; we omit it.
+        stream.receiving_ended = True
+        if stream.is_ended():
+            self._stream.pop(stream_id, None)
+        self._blocked_stream_map.pop(stream_id, None)
+
+        return [H3StreamReset(stream_id=stream_id, error_code=error_code)]
+
+    def _receive_stop_sending(self, stream_id: int, error_code: int) -> list[H3Event]:
+        # RFC 9114 6.2.1: a peer-initiated reset of a critical stream is a
+        # connection error of type H3_CLOSED_CRITICAL_STREAM.
+        if self._is_critical_stream(stream_id):
+            raise ClosedCriticalStream(
+                f"Critical stream {stream_id} stop-sending by peer"
+            )
+
+        stream = self._stream.get(stream_id)
+        if stream is not None:
+            stream.sending_ended = True
+            if stream.is_ended():
+                self._stream.pop(stream_id, None)
+        # The blocked-stream map references this stream by id; drop it so
+        # H3 does not retain state for a stream the application is no
+        # longer expected to write to.
+        self._blocked_stream_map.pop(stream_id, None)
+
+        return [H3StopSending(stream_id=stream_id, error_code=error_code)]
 
     def send_datagram(self, flow_id: int, data: bytes) -> None:
         """
@@ -638,6 +708,9 @@ class H3Connection:
     def _maybe_cleanup_stream(self, stream: H3Stream) -> None:
         if stream.is_ended():
             self._stream.pop(stream.stream_id, None)
+            # Defensive: a stream that completes while it was waiting on
+            # a QPACK dynamic-table update is no longer of interest.
+            self._blocked_stream_map.pop(stream.stream_id, None)
 
     def _get_local_settings(self) -> dict[int, int]:
         """

--- a/qh3/h3/connection.py
+++ b/qh3/h3/connection.py
@@ -154,6 +154,10 @@ class ClosedCriticalStream(ProtocolError):
     error_code = ErrorCode.H3_CLOSED_CRITICAL_STREAM
 
 
+class FrameError(ProtocolError):
+    error_code = ErrorCode.H3_FRAME_ERROR
+
+
 class FrameUnexpected(ProtocolError):
     error_code = ErrorCode.H3_FRAME_UNEXPECTED
 
@@ -760,6 +764,11 @@ class H3Connection:
                     stream.headers_recv_state = HeadersState.AFTER_HEADERS
             else:
                 stream.headers_recv_state = HeadersState.AFTER_TRAILERS
+                # Trailers are the final HTTP message element (RFC 9114 4.1).
+                # If the QUIC stream has ended, force stream_ended regardless
+                # of whether trailing frames (GREASE, etc.) remain in the buffer.
+                if stream.receiving_ended:
+                    stream_ended = True
 
             if (
                 stream.headers_recv_state is HeadersState.INITIAL
@@ -946,12 +955,14 @@ class H3Connection:
             if not s_buffer:
                 data_len = len(data)
                 if data_len < stream.frame_size:
+                    if stream_ended:
+                        raise FrameError("DATA frame truncated by stream end")
                     http_events.append(
                         DataReceived(
                             data=data,
                             push_id=stream.push_id,
                             stream_id=s_stream_id,
-                            stream_ended=stream_ended,
+                            stream_ended=False,
                         )
                     )
                     stream.frame_size -= data_len
@@ -961,12 +972,14 @@ class H3Connection:
                 s_buffer.extend(data)
                 buf_len = len(s_buffer)
                 if buf_len < stream.frame_size:
+                    if stream_ended:
+                        raise FrameError("DATA frame truncated by stream end")
                     http_events.append(
                         DataReceived(
                             data=bytes(s_buffer),
                             push_id=stream.push_id,
                             stream_id=s_stream_id,
-                            stream_ended=stream_ended,
+                            stream_ended=False,
                         )
                     )
                     stream.frame_size -= buf_len
@@ -977,14 +990,16 @@ class H3Connection:
 
         # handle lone FIN
         if stream_ended and not s_buffer and not data:
-            return [
-                DataReceived(
-                    data=b"",
-                    push_id=stream.push_id,
-                    stream_id=s_stream_id,
-                    stream_ended=True,
-                )
-            ]
+            if stream.headers_recv_state is not HeadersState.INITIAL:
+                return [
+                    DataReceived(
+                        data=b"",
+                        push_id=stream.push_id,
+                        stream_id=s_stream_id,
+                        stream_ended=True,
+                    )
+                ]
+            return []
 
         if data:
             s_buffer.extend(data)
@@ -1075,9 +1090,37 @@ class H3Connection:
                 self._blocked_stream_map[s_stream_id] = stream
                 break
 
+            # Trailers are the final HTTP message element (RFC 9114 4.1).
+            # Once received, swallow any remaining frames in the buffer.
+            if (
+                stream.headers_recv_state is HeadersState.AFTER_TRAILERS
+                and stream.receiving_ended
+            ):
+                consumed = len(s_buffer)
+                break
+
         # remove processed data from buffer
         if consumed:
             del s_buffer[:consumed]
+
+        # If the stream ended but no event carried stream_ended=True
+        # (e.g. the last frame was GREASE or PUSH_PROMISE after DATA),
+        # emit a closing DataReceived so the consumer knows the stream
+        # is done. Skip if QPACK-blocked or if trailers already
+        # delivered stream_ended.
+        if stream_ended and not s_buffer and not stream.blocked:
+            if stream.headers_recv_state is HeadersState.AFTER_HEADERS:
+                if not http_events or not getattr(
+                    http_events[-1], "stream_ended", False
+                ):
+                    http_events.append(
+                        DataReceived(
+                            data=b"",
+                            push_id=stream.push_id,
+                            stream_id=s_stream_id,
+                            stream_ended=True,
+                        )
+                    )
 
         return http_events
 

--- a/qh3/h3/connection.py
+++ b/qh3/h3/connection.py
@@ -302,8 +302,10 @@ def validate_response_headers(headers: Headers) -> int | None:
 
     try:
         return int(status_code)
-    except ValueError:  # Defensive:
-        return None
+    except ValueError:
+        raise MessageError(
+            f"Invalid :status value {status_code!r}"
+        ) from None
 
 
 def validate_trailers(headers: Headers) -> None:

--- a/qh3/h3/events.py
+++ b/qh3/h3/events.py
@@ -126,3 +126,31 @@ class WebTransportStreamDataReceived(H3Event):
 
     session_id: int
     "The ID of the session the data was received for."
+
+
+@dataclass
+class StreamReset(H3Event):
+    """
+    Fired when the remote peer abruptly resets a request stream
+    (RFC 9000 RESET_STREAM). The stream will produce no further events.
+    """
+
+    stream_id: int
+    "The ID of the stream that was reset."
+
+    error_code: int
+    "The application error code carried by the RESET_STREAM frame."
+
+
+@dataclass
+class StopSending(H3Event):
+    """
+    Fired when the remote peer asks us to stop sending on a stream
+    (RFC 9000 STOP_SENDING). The local sender side has been reset.
+    """
+
+    stream_id: int
+    "The ID of the stream the peer asked us to stop sending on."
+
+    error_code: int
+    "The application error code carried by the STOP_SENDING frame."

--- a/qh3/quic/configuration.py
+++ b/qh3/quic/configuration.py
@@ -104,7 +104,10 @@ class QuicConfiguration:
     certificate_chain: list[X509Certificate] = field(default_factory=list)
 
     cipher_suites: list[CipherSuite] | None = None
-    initial_rtt: float = 0.1
+    # RFC 9002 6.2.2: a sender SHOULD use kInitialRtt = 333 ms when no
+    # previous RTT is available. Previously this was 100 ms which leads
+    # to spurious early PTO probes in slow networks.
+    initial_rtt: float = 0.333
 
     max_datagram_frame_size: int | None = None
     original_version: int | None = None

--- a/qh3/quic/connection.py
+++ b/qh3/quic/connection.py
@@ -3646,7 +3646,7 @@ class QuicConnection:
                         )
                     self._streams_blocked_pending = False
 
-                # MAX_DATA and MAX_STREAMS - inlined from _write_connection_limits
+                # MAX_DATA and MAX_STREAMS
                 for limit in (
                     self._local_max_data,
                     self._local_max_streams_bidi,
@@ -3676,7 +3676,7 @@ class QuicConnection:
                                 )
                             )
 
-            # stream-level limits - inlined from _write_stream_limits
+            # stream-level limits
             dirty_limits = self._streams_dirty_limits
             if dirty_limits:
                 for stream in dirty_limits:
@@ -3993,39 +3993,6 @@ class QuicConnection:
                 )
             )
 
-    def _write_connection_limits(
-        self, builder: QuicPacketBuilder, space: QuicPacketSpace
-    ) -> None:
-        """
-        Raise MAX_DATA or MAX_STREAMS if needed.
-        """
-        for limit in (
-            self._local_max_data,
-            self._local_max_streams_bidi,
-            self._local_max_streams_uni,
-        ):
-            if limit.used * 2 > limit.value:
-                limit.value *= 2
-                self._logger.debug("Local %s raised to %d", limit.name, limit.value)
-            if limit.value != limit.sent:
-                buf = builder.start_frame(
-                    limit.frame_type,
-                    capacity=CONNECTION_LIMIT_FRAME_CAPACITY,
-                    handler=self._on_connection_limit_delivery,
-                    handler_args=(limit,),
-                )
-                buf.push_uint_var(limit.value)
-                limit.sent = limit.value
-
-                # log frame
-                if self._quic_logger is not None:
-                    builder.quic_logger_frames.append(
-                        self._quic_logger.encode_connection_limit_frame(
-                            frame_type=limit.frame_type,
-                            maximum=limit.value,
-                        )
-                    )
-
     def _write_crypto_frame(
         self, builder: QuicPacketBuilder, space: QuicPacketSpace, stream: QuicStream
     ) -> bool:
@@ -4242,93 +4209,6 @@ class QuicConnection:
                     error_code=frame.error_code, stream_id=frame.stream_id
                 )
             )
-
-    def _write_stream_frame(
-        self,
-        builder: QuicPacketBuilder,
-        space: QuicPacketSpace,
-        stream: QuicStream,
-        max_offset: int,
-    ) -> int:
-        sender = stream.sender
-        stream_id = stream.stream_id
-
-        flight_space = (
-            builder._flight_capacity - builder._buffer.tell() - builder._aead_tag_size
-        )
-        result = sender.prepare_stream_frame(flight_space, max_offset)
-
-        if result is not None:
-            (
-                f_data,
-                frame_type,
-                f_offset,
-                stop_offset,
-                previous_send_highest,
-                frame_overhead,
-            ) = result
-            buf = builder.start_frame(
-                frame_type,
-                frame_overhead,
-                sender.on_data_delivery,
-                (f_offset, stop_offset),
-            )
-            push_stream_frame_body(buf, stream_id, f_offset, f_data)
-
-            # log frame
-            if self._quic_logger is not None:
-                builder.quic_logger_frames.append(
-                    self._quic_logger.encode_stream_frame(
-                        bool(frame_type & 1), f_data, f_offset, stream_id=stream_id
-                    )
-                )
-
-            return sender.highest_offset - previous_send_highest
-        else:
-            return 0
-
-    def _write_stream_limits(
-        self, builder: QuicPacketBuilder, space: QuicPacketSpace, stream: QuicStream
-    ) -> None:
-        """
-        Raise MAX_STREAM_DATA if needed.
-
-        The only case where `stream.max_stream_data_local` is zero is for
-        locally created unidirectional streams. We skip such streams to avoid
-        spurious logging.
-        """
-        # RFC 9000 3.2: do not advertise additional credit on streams
-        # whose receive part is in "Data Recvd" or "Reset Recvd".
-        if stream.receiver.is_finished:
-            return
-        if (
-            stream.max_stream_data_local
-            and stream.receiver.highest_offset * 2 > stream.max_stream_data_local
-        ):
-            stream.max_stream_data_local *= 2
-            self._logger.debug(
-                "Stream %d local max_stream_data raised to %d",
-                stream.stream_id,
-                stream.max_stream_data_local,
-            )
-        if stream.max_stream_data_local_sent != stream.max_stream_data_local:
-            buf = builder.start_frame(
-                QuicFrameType.MAX_STREAM_DATA,
-                capacity=MAX_STREAM_DATA_FRAME_CAPACITY,
-                handler=self._on_max_stream_data_delivery,
-                handler_args=(stream,),
-            )
-            buf.push_uint_var(stream.stream_id)
-            buf.push_uint_var(stream.max_stream_data_local)
-            stream.max_stream_data_local_sent = stream.max_stream_data_local
-
-            # log frame
-            if self._quic_logger is not None:
-                builder.quic_logger_frames.append(
-                    self._quic_logger.encode_max_stream_data_frame(
-                        maximum=stream.max_stream_data_local, stream_id=stream.stream_id
-                    )
-                )
 
     def _write_streams_blocked_frame(
         self, builder: QuicPacketBuilder, frame_type: QuicFrameType, limit: int

--- a/qh3/quic/connection.py
+++ b/qh3/quic/connection.py
@@ -2597,6 +2597,23 @@ class QuicConnection:
         if delivery != QuicDeliveryState.ACKED:
             limit.sent = 0
 
+    def _on_streams_blocked_delivery(
+        self, delivery: QuicDeliveryState, is_unidirectional: bool
+    ) -> None:
+        """
+        Callback when a STREAMS_BLOCKED frame is acknowledged or lost.
+
+        Re-arms the pending flag on loss if blocked streams still exist,
+        per RFC 9000 13.3 (SHOULD retransmit if conditions persist).
+        """
+        if delivery != QuicDeliveryState.ACKED:
+            if is_unidirectional:
+                if self._streams_blocked_uni:
+                    self._streams_blocked_pending = True
+            else:
+                if self._streams_blocked_bidi:
+                    self._streams_blocked_pending = True
+
     def _on_handshake_done_delivery(self, delivery: QuicDeliveryState) -> None:
         """
         Callback when a HANDSHAKE_DONE frame is acknowledged or lost.
@@ -4020,7 +4037,13 @@ class QuicConnection:
     def _write_streams_blocked_frame(
         self, builder: QuicPacketBuilder, frame_type: QuicFrameType, limit: int
     ) -> None:
-        buf = builder.start_frame(frame_type, capacity=STREAMS_BLOCKED_CAPACITY)
+        is_uni = frame_type == QuicFrameType.STREAMS_BLOCKED_UNI
+        buf = builder.start_frame(
+            frame_type,
+            capacity=STREAMS_BLOCKED_CAPACITY,
+            handler=self._on_streams_blocked_delivery,
+            handler_args=(is_uni,),
+        )
         buf.push_uint_var(limit)
 
         # log frame

--- a/qh3/quic/connection.py
+++ b/qh3/quic/connection.py
@@ -1886,7 +1886,9 @@ class QuicConnection:
             self._crypto_frame_type = frame_type
             self._crypto_packet_version = context.version
             try:
-                self.tls.handle_message(event.data, self._crypto_buffers)
+                self.tls.handle_message(
+                    event.data, self._crypto_buffers, epoch=context.epoch
+                )
                 self._push_crypto_data()
             except tls.AlertECHRequired as exc:
                 # ECH was offered but rejected. Store retry_configs before

--- a/qh3/quic/connection.py
+++ b/qh3/quic/connection.py
@@ -828,6 +828,10 @@ class QuicConnection:
                 probe_builder._buffer.push_bytes(bytes(pad_size))
             probe_datagrams, probe_packets = probe_builder.flush()
             if probe_datagrams:
+                # RFC 9000 14.4: tag probe packets so loss detection
+                # does not trigger a congestion control reaction.
+                for probe_pkt in probe_packets:
+                    probe_pkt.is_pmtu_probe = True
                 datagrams.extend(probe_datagrams)
                 packets.extend(probe_packets)
                 builder = probe_builder

--- a/qh3/quic/connection.py
+++ b/qh3/quic/connection.py
@@ -318,6 +318,8 @@ class QuicConnection:
         "_remote_active_connection_id_limit",
         "_remote_initial_source_connection_id",
         "_remote_max_idle_timeout",
+        "_remote_max_ack_delay",
+        "_ack_eliciting_sent_since_receive",
         "_remote_max_data",
         "_remote_max_data_used",
         "_remote_max_datagram_frame_size",
@@ -346,6 +348,9 @@ class QuicConnection:
         "_logger",
         "_loss",
         "_close_pending",
+        "_close_packets_received_since_send",
+        "_close_packets_send_threshold",
+        "_handshake_keys_discard_pending",
         "_datagrams_pending",
         "_handshake_done_pending",
         "_ping_pending",
@@ -466,6 +471,8 @@ class QuicConnection:
         self._remote_active_connection_id_limit = 2
         self._remote_initial_source_connection_id: bytes | None = None
         self._remote_max_idle_timeout = 0.0  # seconds
+        self._remote_max_ack_delay = 0.025  # seconds, RFC 9000 default
+        self._ack_eliciting_sent_since_receive = False
         self._effective_idle_timeout: float = self._configuration.idle_timeout
         self._remote_max_data = 0
         self._remote_max_data_used = 0
@@ -519,9 +526,15 @@ class QuicConnection:
             quic_logger=self._quic_logger,
             logger=self._logger,
         )
+        # RFC 9002 6.2.1: until the handshake is confirmed, the PTO
+        # computation MUST use a max_ack_delay of 0.
+        self._loss.max_ack_delay = 0.0
 
         # things to send
         self._close_pending = False
+        self._close_packets_received_since_send = 0
+        self._close_packets_send_threshold = 1
+        self._handshake_keys_discard_pending = False
         self._datagrams_pending: deque[bytes] = deque()
         self._handshake_done_pending = False
         self._ping_pending: list[int] = []
@@ -692,7 +705,26 @@ class QuicConnection:
         """
         network_path = self._network_paths[0]
 
-        if self._state in END_STATES:
+        # Capture the current 1-RTT send key_phase so we can detect a
+        # local-initiated key update that occurs while encrypting and
+        # arrange for the previous recv key to be retained for 3*PTO
+        # (RFC 9001 6.5).
+        _onertt_crypto = self._cryptos[tls.Epoch.ONE_RTT]
+        _kp_before = (
+            _onertt_crypto.send.key_phase if _onertt_crypto.send.is_valid() else None
+        )
+        # opportunistically expire any previously retained recv keys
+        _onertt_crypto.expire_previous_keys(now)
+
+        # Allow CONNECTION_CLOSE retransmissions even after we have
+        # transitioned to CLOSING. RFC 9000 10.2.1 SHOULD-resend semantics.
+        if (
+            self._state == QuicConnectionState.CLOSING
+            and self._close_pending
+            and self._close_event is not None
+        ):
+            pass  # fall through to the close-pending block below
+        elif self._state in END_STATES:
             return []
 
         # build datagrams
@@ -817,6 +849,19 @@ class QuicConnection:
                 loss_on_packet_sent(packet=packet, space=spaces[packet.epoch])
                 if packet.epoch == tls.Epoch.HANDSHAKE:
                     sent_handshake = True
+                # RFC 9000 10.1: restart the idle timer when sending an
+                # ack-eliciting packet if no other ack-eliciting packets
+                # have been sent since the last receive.
+                if (
+                    packet.is_ack_eliciting
+                    and not self._ack_eliciting_sent_since_receive
+                ):
+                    self._ack_eliciting_sent_since_receive = True
+                    deadline = self._idle_deadline(now)
+                    if deadline is not None and (
+                        self._close_at is None or deadline > self._close_at
+                    ):
+                        self._close_at = deadline
 
                 # log packet
                 if quic_logger is not None:
@@ -844,6 +889,19 @@ class QuicConnection:
             # check if we can discard initial keys
             if sent_handshake and self._is_client:
                 self._discard_epoch(tls.Epoch.INITIAL)
+
+        # If a local-initiated 1-RTT key update happened during this
+        # send pass, retain the previous receive key for 3*PTO so we
+        # can still decrypt reordered packets sent under the old key
+        # (RFC 9001 6.5).
+        if (
+            _kp_before is not None
+            and _onertt_crypto.send.is_valid()
+            and _onertt_crypto.send.key_phase != _kp_before
+        ):
+            _onertt_crypto.retain_previous_keys(
+                now + 3 * self._loss.get_probe_timeout()
+            )
 
         # return datagrams to send and the destination network address
         addr = network_path.addr
@@ -908,6 +966,18 @@ class QuicConnection:
 
         return timer_at
 
+    def _idle_deadline(self, now: float) -> float | None:
+        """
+        Compute the next idle-timeout deadline, or None if no idle
+        timeout is in effect. RFC 9000 10.1.1: the idle timeout period
+        MUST be at least three times the current PTO.
+        """
+        timeout = self._effective_idle_timeout
+        if timeout <= 0:
+            return None
+        floor = 3 * self._loss.get_probe_timeout()
+        return now + max(timeout, floor)
+
     def handle_timer(self, now: float) -> None:
         """
         Handle the timer.
@@ -918,7 +988,7 @@ class QuicConnection:
         :param now: The current time.
         """
         # end of closing period or idle timeout
-        if now >= self._close_at:
+        if self._close_at is not None and now >= self._close_at:
             if self._close_event is None:
                 self._close_event = events.ConnectionTerminated(
                     error_code=QuicErrorCode.INTERNAL_ERROR,
@@ -956,6 +1026,23 @@ class QuicConnection:
         """
         # stop handling packets when closing
         if self._state in END_STATES:
+            # RFC 9000 10.2.1: while in CLOSING, an endpoint SHOULD send
+            # a packet containing a CONNECTION_CLOSE frame in response to
+            # received packets, but MUST limit the rate. Trigger a
+            # retransmission with exponential backoff (after 1, 2, 4, 8,
+            # ... incoming datagrams).
+            if (
+                self._state == QuicConnectionState.CLOSING
+                and self._close_event is not None
+            ):
+                self._close_packets_received_since_send += 1
+                if (
+                    self._close_packets_received_since_send
+                    >= self._close_packets_send_threshold
+                ):
+                    self._close_packets_received_since_send = 0
+                    self._close_packets_send_threshold *= 2
+                    self._close_pending = True
             return
 
         payload_length = len(data)
@@ -996,7 +1083,7 @@ class QuicConnection:
 
         # for servers, arm the idle timeout on the first datagram
         if self._close_at is None:
-            self._close_at = now + self._configuration.idle_timeout
+            self._close_at = self._idle_deadline(now)
 
         _data_len = len(data)
         _offset = 0
@@ -1119,9 +1206,24 @@ class QuicConnection:
 
             # decrypt packet
             try:
+                # remember key phase before decryption to detect rotation
+                _kp_before = (
+                    crypto.recv.key_phase
+                    if epoch in (tls.Epoch.ONE_RTT, tls.Epoch.ZERO_RTT)
+                    else None
+                )
+                # opportunistically expire previously retained recv keys
+                if _kp_before is not None:
+                    crypto.expire_previous_keys(now)
                 plain_header, plain_payload, packet_number = crypto.decrypt_packet(
                     data[start_off:end_off], encrypted_off, space.expected_packet_number
                 )
+                # if a key rotation just happened, schedule retention of
+                # the previous keys for 3*PTO (RFC 9001 6.5).
+                if _kp_before is not None and crypto.recv.key_phase != _kp_before:
+                    crypto.retain_previous_keys(
+                        now + 3 * self._loss.get_probe_timeout()
+                    )
             except KeyUnavailableError as exc:
                 self._logger.debug(exc)
                 if quic_logger is not None:
@@ -1155,6 +1257,18 @@ class QuicConnection:
                             "raw": {"length": _packet_length},
                         },
                     )
+                # RFC 9000 10.3: a UDP datagram whose trailing 16 bytes match
+                # a stateless reset token issued by the peer is a stateless
+                # reset and indicates the peer has lost connection state.
+                if self._is_stateless_reset(data):
+                    self._logger.info("Stateless reset received from peer")
+                    self._close_event = events.ConnectionTerminated(
+                        error_code=QuicErrorCode.NO_ERROR,
+                        frame_type=None,
+                        reason_phrase="Stateless reset",
+                    )
+                    self._close_end()
+                    return
                 continue
 
             # check reserved bits
@@ -1228,6 +1342,18 @@ class QuicConnection:
                     self._spin_bit = spin_bit
                 self._spin_highest_pn = packet_number
 
+            # RFC 9001 4.9.2: server discards Handshake keys upon receiving
+            # a 1-RTT packet from the client; this proves the client has
+            # installed 1-RTT keys and so will not retransmit Handshake
+            # CRYPTO any longer.
+            if (
+                not is_client
+                and self._handshake_keys_discard_pending
+                and epoch == tls.Epoch.ONE_RTT
+            ):
+                self._handshake_keys_discard_pending = False
+                self._discard_epoch(tls.Epoch.HANDSHAKE)
+
                 if quic_logger is not None:
                     quic_logger.log_event(
                         category="connectivity",
@@ -1259,7 +1385,8 @@ class QuicConnection:
                 return
 
             # update idle timeout
-            self._close_at = now + self._effective_idle_timeout
+            self._close_at = self._idle_deadline(now)
+            self._ack_eliciting_sent_since_receive = False
 
             # handle migration
             if (
@@ -1288,6 +1415,10 @@ class QuicConnection:
                 self._logger.debug("Network path %s promoted", network_path.addr)
                 self._network_paths.pop(idx)
                 self._network_paths.insert(0, network_path)
+                # RFC 9000 9.4 / RFC 9002 5.1: drop RTT samples gathered
+                # on the previous path; the new path may have very
+                # different latency.
+                self._loss.reset_for_new_path()
 
             # record packet as received
             if not space.discarded:
@@ -1302,7 +1433,11 @@ class QuicConnection:
         """
         Request an update of the encryption keys.
         """
-        assert self._handshake_complete, "cannot change key before handshake completes"
+        # RFC 9001 6.1: an endpoint MUST NOT initiate a key update until
+        # the handshake is confirmed.
+        assert self._handshake_confirmed, (
+            "cannot change key before handshake is confirmed"
+        )
         self._cryptos[tls.Epoch.ONE_RTT].update_key()
 
     def reset_stream(self, stream_id: int, error_code: int) -> None:
@@ -1489,7 +1624,7 @@ class QuicConnection:
         """
         assert self._is_client
 
-        self._close_at = now + self._configuration.idle_timeout
+        self._close_at = self._idle_deadline(now)
         self._initialize(self._peer_cid.cid)
 
         self.tls.handle_message(b"", self._crypto_buffers)
@@ -1508,6 +1643,25 @@ class QuicConnection:
                     crypto.teardown()
             self._loss.discard_space(self._spaces[epoch])
             self._spaces[epoch].discarded = True
+
+    def _discard_zero_rtt_keys(self) -> None:
+        """
+        RFC 9001 4.9.3: 0-RTT keys MUST be discarded once they are no
+        longer needed.
+
+        - A server MUST discard 0-RTT keys after receiving a 1-RTT
+          packet, or earlier if it has decided not to accept 0-RTT.
+        - A client MUST discard 0-RTT keys when it receives the
+          Handshake keys (or as soon as the handshake is confirmed).
+
+        0-RTT shares the 1-RTT packet-number space, so we only tear down
+        the crypto pair; there is no separate ``QuicPacketSpace`` to
+        discard.
+        """
+        zero_rtt = self._cryptos[tls.Epoch.ZERO_RTT]
+        if zero_rtt.send.is_valid() or zero_rtt.recv.is_valid():
+            self._logger.debug("Discarding 0-RTT keys")
+            zero_rtt.teardown()
 
     def _find_network_path(self, addr: NetworkAddress) -> QuicNetworkPath:
         # check existing network paths
@@ -1791,6 +1945,18 @@ class QuicConnection:
                 self._quic_logger.encode_ack_frame(ack_rangeset, ack_delay)
             )
 
+        # RFC 9000 19.3.1: a receiver MUST treat as a connection error of
+        # type PROTOCOL_VIOLATION any ACK that acknowledges a packet number
+        # that the receiver has never sent.
+        space = self._spaces[context.epoch]
+        largest_acked = ack_rangeset.bounds()[1] - 1
+        if largest_acked >= space.packet_number:
+            raise QuicConnectionError(
+                error_code=QuicErrorCode.PROTOCOL_VIOLATION,
+                frame_type=frame_type,
+                reason_phrase="ACK acknowledges unsent packet",
+            )
+
         # check whether peer completed address validation
         if not self._loss.peer_completed_address_validation and context.epoch in (
             tls.Epoch.HANDSHAKE,
@@ -1799,10 +1965,17 @@ class QuicConnection:
             self._loss.peer_completed_address_validation = True
 
         self._loss.on_ack_received(
-            space=self._spaces[context.epoch],
+            space=space,
             ack_rangeset=ack_rangeset,
             ack_delay=ack_delay,
             now=context.time,
+            # RFC 9002 6.2.1: a client MUST NOT reset its PTO backoff
+            # on an ACK that only acknowledges Initial packets, because
+            # it has no proof yet that the server has finished validating
+            # the client address.
+            reset_pto_count=not (
+                self._is_client and context.epoch == tls.Epoch.INITIAL
+            ),
         )
 
     def _handle_connection_close_frame(
@@ -1915,9 +2088,23 @@ class QuicConnection:
 
                 # for servers, the handshake is now confirmed
                 if not self._is_client:
-                    self._discard_epoch(tls.Epoch.HANDSHAKE)
+                    # RFC 9001 4.9.2: defer Handshake key discard until we
+                    # have evidence the client received our Handshake keys.
+                    # We discard upon receiving any 1-RTT packet from the
+                    # client. This prevents losing client-retransmitted
+                    # Handshake CRYPTO that arrives after our handshake
+                    # completes (which would otherwise cause a client hang).
+                    self._handshake_keys_discard_pending = True
                     self._handshake_confirmed = True
                     self._handshake_done_pending = True
+                    # RFC 9002 6.2.1: max_ack_delay only applies after the
+                    # handshake is confirmed.
+                    self._loss.max_ack_delay = self._remote_max_ack_delay
+                    # RFC 9001 4.9.3: server discards 0-RTT receive keys
+                    # once the handshake is complete (no further 0-RTT
+                    # data can usefully arrive). We discard send keys too;
+                    # servers never send 0-RTT.
+                    self._discard_zero_rtt_keys()
 
                 self._replenish_connection_ids()
                 self._events.append(
@@ -1959,6 +2146,18 @@ class QuicConnection:
         if self._quic_logger is not None:
             context.quic_logger_frames.append(
                 self._quic_logger.encode_data_blocked_frame(limit=limit)
+            )
+
+        # RFC 9000 4.1: a DATA_BLOCKED at our advertised connection-level
+        # limit is a hint that the peer would benefit from more credit.
+        # Bump the local connection-level MAX_DATA so a fresh frame is
+        # sent on the next write.
+        if limit >= self._local_max_data.value:
+            self._local_max_data.value *= 2
+            self._logger.debug(
+                "Local %s raised to %d in response to DATA_BLOCKED",
+                self._local_max_data.name,
+                self._local_max_data.value,
             )
 
     def _handle_datagram_frame(
@@ -2017,6 +2216,13 @@ class QuicConnection:
             self._discard_epoch(tls.Epoch.HANDSHAKE)
             self._handshake_confirmed = True
             self._loss.peer_completed_address_validation = True
+            # RFC 9002 6.2.1: max_ack_delay only applies after the
+            # handshake is confirmed.
+            self._loss.max_ack_delay = self._remote_max_ack_delay
+            # RFC 9001 4.9.3: a client MUST discard its 0-RTT keys once
+            # the handshake is confirmed (Handshake keys received +
+            # HANDSHAKE_DONE).
+            self._discard_zero_rtt_keys()
 
     def _handle_max_data_frame(
         self, context: QuicReceiveContext, frame_type: int, buf: Buffer
@@ -2532,7 +2738,25 @@ class QuicConnection:
         # check stream direction
         self._assert_stream_can_receive(frame_type, stream_id)
 
-        self._get_or_create_stream(frame_type, stream_id)
+        stream = self._get_or_create_stream(frame_type, stream_id)
+
+        # RFC 9000 4.1: STREAM_DATA_BLOCKED at the limit we advertised
+        # is a hint that the peer is wedged on flow control. If we still
+        # consider the stream live (not finished, not reset), grant more
+        # credit and queue a MAX_STREAM_DATA on the next write.
+        if (
+            not stream.receiver.is_finished
+            and stream.max_stream_data_local
+            and limit >= stream.max_stream_data_local
+        ):
+            stream.max_stream_data_local *= 2
+            self._logger.debug(
+                "Stream %d local max_stream_data raised to %d in response to "
+                "STREAM_DATA_BLOCKED",
+                stream_id,
+                stream.max_stream_data_local,
+            )
+            self._streams_dirty_limits.add(stream)
 
     def _handle_streams_blocked_frame(
         self, context: QuicReceiveContext, frame_type: int, buf: Buffer
@@ -2960,6 +3184,25 @@ class QuicConnection:
     def _send_probe(self) -> None:
         self._probe_pending = True
 
+    def _is_stateless_reset(self, datagram: bytes) -> bool:
+        """
+        RFC 9000 10.3.1: detect a stateless reset by matching the trailing
+        16 bytes of the UDP datagram against the stateless reset tokens
+        the peer has shared with us.
+        """
+        if len(datagram) < STATELESS_RESET_TOKEN_SIZE:
+            return False
+        token = datagram[-STATELESS_RESET_TOKEN_SIZE:]
+        if (
+            self._peer_cid.stateless_reset_token
+            and token == self._peer_cid.stateless_reset_token
+        ):
+            return True
+        for cid in self._peer_cid_available:
+            if cid.stateless_reset_token and token == cid.stateless_reset_token:
+                return True
+        return False
+
     def _parse_transport_parameters(
         self, data: bytes, from_session_ticket: bool = False
     ) -> None:
@@ -3111,11 +3354,17 @@ class QuicConnection:
         # store remote parameters
         if not from_session_ticket:
             if quic_transport_parameters.ack_delay_exponent is not None:
-                self._remote_ack_delay_exponent = self._remote_ack_delay_exponent
+                self._remote_ack_delay_exponent = (
+                    quic_transport_parameters.ack_delay_exponent
+                )
             if quic_transport_parameters.max_ack_delay is not None:
-                self._loss.max_ack_delay = (
+                self._remote_max_ack_delay = (
                     quic_transport_parameters.max_ack_delay / 1000.0
                 )
+                # RFC 9002 6.2.1: max_ack_delay MUST NOT be applied to PTO
+                # before the handshake is confirmed.
+                if self._handshake_confirmed:
+                    self._loss.max_ack_delay = self._remote_max_ack_delay
             if (
                 self._is_client
                 and self._peer_cid.sequence_number == 0
@@ -3136,14 +3385,19 @@ class QuicConnection:
             self._remote_max_idle_timeout = (
                 quic_transport_parameters.max_idle_timeout / 1000.0
             )
-            # RFC 9000 10.1: effective idle timeout is the minimum of the
-            # two advertised values. A zero value means the peer does not
-            # have a timeout.
-            if self._remote_max_idle_timeout > 0:
-                self._effective_idle_timeout = min(
-                    self._configuration.idle_timeout,
-                    self._remote_max_idle_timeout,
-                )
+            # RFC 9000 10.1: the effective idle timeout is the minimum of
+            # the values advertised by the two endpoints, treating a value
+            # of 0 as "no timeout". If both are 0, no idle timeout applies.
+            local = self._configuration.idle_timeout
+            remote = self._remote_max_idle_timeout
+            if local > 0 and remote > 0:
+                self._effective_idle_timeout = min(local, remote)
+            elif local > 0:
+                self._effective_idle_timeout = local
+            elif remote > 0:
+                self._effective_idle_timeout = remote
+            else:
+                self._effective_idle_timeout = 0.0
         self._remote_max_datagram_frame_size = (
             quic_transport_parameters.max_datagram_frame_size
         )
@@ -3316,8 +3570,12 @@ class QuicConnection:
         _quic_logger = self._quic_logger
 
         while True:
-            # apply pacing, except if we have ACKs to send
-            if space.ack_at is None or space.ack_at >= now:
+            # apply pacing, except if we have ACKs to send or a PTO probe
+            # is pending (RFC 9002 7.7: pacing MUST NOT delay packets sent
+            # in response to a PTO timer expiry).
+            if (
+                space.ack_at is None or space.ack_at >= now
+            ) and not self._probe_pending:
                 self._pacing_at = pacer.next_send_time(now=now)
                 if self._pacing_at is not None:
                     break
@@ -3422,6 +3680,11 @@ class QuicConnection:
             dirty_limits = self._streams_dirty_limits
             if dirty_limits:
                 for stream in dirty_limits:
+                    # RFC 9000 3.2: once a stream's receive part is in
+                    # "Data Recvd" or "Reset Recvd", further flow-control
+                    # credit is meaningless and MUST NOT be sent.
+                    if stream.receiver.is_finished:
+                        continue
                     if (
                         stream.max_stream_data_local
                         and stream.receiver.highest_offset * 2
@@ -3644,9 +3907,29 @@ class QuicConnection:
         ack_delay = now - space.largest_received_time
         ack_delay_encoded = int(ack_delay * 1000000) >> self._local_ack_delay_exponent
 
+        # Dynamically size the ACK frame: header (largest_acked, ack_delay,
+        # range_count, first_range) takes up to 32 bytes; each additional
+        # range adds two varints, up to 16 bytes. Trim oldest ranges
+        # (RFC 9000 13.2.4 explicitly allows it) when the packet has
+        # insufficient room rather than dropping the entire ACK.
+        # We reserve 1 byte for the frame type, accounted for separately
+        # by start_frame.
+        ranges_count = len(space.ack_queue)
+        # remaining_buffer_space already excludes AEAD tag.
+        # subtract 1 for frame type byte.
+        max_payload = max(builder.remaining_buffer_space - 1, 0)
+        max_ranges_by_space = max((max_payload - 32) // 16, 0)
+        if ranges_count > max_ranges_by_space and max_ranges_by_space > 0:
+            # drop oldest ranges (lowest packet numbers); the peer will
+            # have to assume those were lost or already retired.
+            while len(space.ack_queue) > max_ranges_by_space:
+                space.ack_queue.shift()
+            ranges_count = len(space.ack_queue)
+        capacity = 32 + 16 * max(ranges_count, 1)
+
         buf = builder.start_frame(
             QuicFrameType.ACK,
-            capacity=ACK_FRAME_CAPACITY,
+            capacity=capacity,
             handler=self._on_ack_delivery,
             handler_args=(space, space.largest_received_packet),
         )
@@ -3847,6 +4130,11 @@ class QuicConnection:
         )
         buf.push_bytes(challenge)
 
+        # RFC 9000 8.2.1: datagrams containing PATH_CHALLENGE MUST be
+        # expanded to at least 1200 bytes (subject to the anti-amplification
+        # limit, which the builder already enforces via max_total_bytes).
+        builder.pad_datagram()
+
         # log frame
         if self._quic_logger is not None:
             builder.quic_logger_frames.append(
@@ -3860,6 +4148,10 @@ class QuicConnection:
             QuicFrameType.PATH_RESPONSE, capacity=PATH_RESPONSE_FRAME_CAPACITY
         )
         buf.push_bytes(challenge)
+
+        # RFC 9000 8.2.2: datagrams containing PATH_RESPONSE MUST be
+        # expanded to at least 1200 bytes.
+        builder.pad_datagram()
 
         # log frame
         if self._quic_logger is not None:
@@ -4005,6 +4297,10 @@ class QuicConnection:
         locally created unidirectional streams. We skip such streams to avoid
         spurious logging.
         """
+        # RFC 9000 3.2: do not advertise additional credit on streams
+        # whose receive part is in "Data Recvd" or "Reset Recvd".
+        if stream.receiver.is_finished:
+            return
         if (
             stream.max_stream_data_local
             and stream.receiver.highest_offset * 2 > stream.max_stream_data_local

--- a/qh3/quic/connection.py
+++ b/qh3/quic/connection.py
@@ -2446,8 +2446,9 @@ class QuicConnection:
         self._assert_stream_can_send(frame_type, stream_id)
 
         # reset the stream
+        # RFC 9000 3.5: SHOULD copy error code from STOP_SENDING to RESET_STREAM
         stream = self._get_or_create_stream(frame_type, stream_id)
-        stream.sender.reset(error_code=QuicErrorCode.NO_ERROR)
+        stream.sender.reset(error_code=error_code)
 
         self._events.append(
             events.StopSendingReceived(error_code=error_code, stream_id=stream_id)

--- a/qh3/quic/crypto.py
+++ b/qh3/quic/crypto.py
@@ -187,6 +187,8 @@ class CryptoPair:
         "recv",
         "send",
         "_update_key_requested",
+        "_previous_recv",
+        "_previous_recv_expires_at",
     )
 
     def __init__(
@@ -200,14 +202,57 @@ class CryptoPair:
         self.recv = CryptoContext(setup_cb=recv_setup_cb, teardown_cb=recv_teardown_cb)
         self.send = CryptoContext(setup_cb=send_setup_cb, teardown_cb=send_teardown_cb)
         self._update_key_requested = False
+        # RFC 9001 6.5: keep the previous receive context for 3*PTO so
+        # reordered packets sent under the previous key can be decrypted.
+        self._previous_recv: CryptoContext | None = None
+        self._previous_recv_expires_at: float | None = None
+
+    def expire_previous_keys(self, now: float) -> None:
+        """Drop the retained previous receive key once 3*PTO has elapsed."""
+        if (
+            self._previous_recv is not None
+            and self._previous_recv_expires_at is not None
+            and now >= self._previous_recv_expires_at
+        ):
+            self._previous_recv.teardown()
+            self._previous_recv = None
+            self._previous_recv_expires_at = None
 
     def decrypt_packet(
         self, packet: bytes, encrypted_offset: int, expected_packet_number: int
     ) -> tuple[bytes, bytes, int]:
-        plain_header, payload, packet_number, update_key = self.recv.decrypt_packet(
-            packet, encrypted_offset, expected_packet_number
-        )
+        try:
+            plain_header, payload, packet_number, update_key = self.recv.decrypt_packet(
+                packet, encrypted_offset, expected_packet_number
+            )
+        except CryptoError:
+            # AEAD failed — possibly a reordered packet sent under the
+            # previous key (RFC 9001 6.5). Try the retained snapshot
+            # before giving up; on success we MUST NOT rotate.
+            if self._previous_recv is not None:
+                plain_header, payload, packet_number, _ = (
+                    self._previous_recv.decrypt_packet(
+                        packet, encrypted_offset, expected_packet_number
+                    )
+                )
+                return plain_header, payload, packet_number
+            raise
         if update_key:
+            # The packet's key phase differs from our current one. It
+            # could be either (a) the peer initiating the next phase, or
+            # (b) a delayed packet sent before a previous local-initiated
+            # update. Try the retained previous key first to avoid
+            # spuriously rotating when (b) applies.
+            if self._previous_recv is not None:
+                try:
+                    plain_header2, payload2, pn2, _ = (
+                        self._previous_recv.decrypt_packet(
+                            packet, encrypted_offset, expected_packet_number
+                        )
+                    )
+                    return plain_header2, payload2, pn2
+                except CryptoError:
+                    pass
             self._update_key("remote_update")
         return plain_header, payload, packet_number
 
@@ -297,6 +342,30 @@ class CryptoPair:
             return self.recv.key_phase
 
     def _update_key(self, trigger: str) -> None:
+        # Snapshot the current receive context so we can keep decrypting
+        # reordered packets under the previous key for 3*PTO
+        # (RFC 9001 6.5). The caller is responsible for setting
+        # _previous_recv_expires_at via retain_previous_keys().
+        if self.recv.is_valid():
+            snapshot = CryptoContext(key_phase=self.recv.key_phase)
+            snapshot.setup(
+                cipher_suite=self.recv.cipher_suite,
+                secret=self.recv.secret,
+                version=self.recv.version,
+            )
+            # Replace any existing snapshot.
+            if self._previous_recv is not None:
+                self._previous_recv.teardown()
+            self._previous_recv = snapshot
+
         apply_key_phase(self.recv, next_key_phase(self.recv), trigger=trigger)
         apply_key_phase(self.send, next_key_phase(self.send), trigger=trigger)
         self._update_key_requested = False
+
+    def retain_previous_keys(self, expires_at: float) -> None:
+        """
+        Schedule the retained previous receive key to be discarded at
+        ``expires_at``. Called by the connection after a key update.
+        """
+        if self._previous_recv is not None:
+            self._previous_recv_expires_at = expires_at

--- a/qh3/quic/packet.py
+++ b/qh3/quic/packet.py
@@ -404,10 +404,16 @@ def push_quic_version_information(
 
 def pull_quic_transport_parameters(buf: Buffer) -> QuicTransportParameters:
     params = QuicTransportParameters()
+    seen: set[int] = set()
     while not buf.eof():
         param_id = buf.pull_uint_var()
         param_len = buf.pull_uint_var()
         param_start = buf.tell()
+        # RFC 9000 7.4: an endpoint MUST NOT send a parameter more than
+        # once. Treat duplicates as TRANSPORT_PARAMETER_ERROR.
+        if param_id in seen:
+            raise ValueError(f"Duplicate transport parameter 0x{param_id:x}")
+        seen.add(param_id)
         if param_id in PARAMS:
             # parse known parameter
             param_name, param_type = PARAMS[param_id]

--- a/qh3/quic/packet_builder.py
+++ b/qh3/quic/packet_builder.py
@@ -53,6 +53,7 @@ class QuicSentPacket:
         "in_flight",
         "is_ack_eliciting",
         "is_crypto_packet",
+        "is_pmtu_probe",
         "packet_number",
         "packet_type",
         "sent_time",
@@ -71,11 +72,13 @@ class QuicSentPacket:
         packet_type: QuicPacketType,
         sent_time: float | None = None,
         sent_bytes: int = 0,
+        is_pmtu_probe: bool = False,
     ) -> None:
         self.epoch = epoch
         self.in_flight = in_flight
         self.is_ack_eliciting = is_ack_eliciting
         self.is_crypto_packet = is_crypto_packet
+        self.is_pmtu_probe = is_pmtu_probe
         self.packet_number = packet_number
         self.packet_type = packet_type
         self.sent_time = sent_time
@@ -91,6 +94,7 @@ class QuicSentPacket:
             and self.in_flight == other.in_flight
             and self.is_ack_eliciting == other.is_ack_eliciting
             and self.is_crypto_packet == other.is_crypto_packet
+            and self.is_pmtu_probe == other.is_pmtu_probe
             and self.packet_number == other.packet_number
             and self.packet_type == other.packet_type
             and self.sent_bytes == other.sent_bytes

--- a/qh3/quic/packet_builder.py
+++ b/qh3/quic/packet_builder.py
@@ -235,6 +235,14 @@ class QuicPacketBuilder:
         """
         return self._flight_capacity - self._buffer.tell() - self._aead_tag_size
 
+    def pad_datagram(self) -> None:
+        """
+        Mark the current datagram as needing to be padded to the full
+        path MTU. Used to satisfy RFC 9000 8.2.1 (PATH_CHALLENGE /
+        PATH_RESPONSE) and similar requirements.
+        """
+        self._datagram_needs_padding = True
+
     def flush(self) -> tuple[list[bytes], list[QuicSentPacket]]:
         """
         Returns the assembled datagrams.

--- a/qh3/quic/recovery.py
+++ b/qh3/quic/recovery.py
@@ -336,7 +336,7 @@ class QuicPacketRecovery:
             self._rtt_latest = max(latest_rtt, 0.001)
             if self._rtt_latest < self._rtt_min:
                 self._rtt_min = self._rtt_latest
-            if self._rtt_latest > self._rtt_min + ack_delay:
+            if self._rtt_latest >= self._rtt_min + ack_delay:
                 self._rtt_latest -= ack_delay
 
             if not self._rtt_initialized:
@@ -345,7 +345,7 @@ class QuicPacketRecovery:
                 self._rtt_smoothed = latest_rtt
             else:
                 self._rtt_variance = 3 / 4 * self._rtt_variance + 1 / 4 * abs(
-                    self._rtt_min - self._rtt_latest
+                    self._rtt_smoothed - self._rtt_latest
                 )
                 self._rtt_smoothed = (
                     7 / 8 * self._rtt_smoothed + 1 / 8 * self._rtt_latest
@@ -446,10 +446,14 @@ class QuicPacketRecovery:
         """
         Check whether any packets should be declared lost.
         """
-        loss_delay = K_TIME_THRESHOLD * (
-            max(self._rtt_latest, self._rtt_smoothed)
-            if self._rtt_initialized
-            else self._rtt_initial
+        loss_delay = max(
+            K_TIME_THRESHOLD
+            * (
+                max(self._rtt_latest, self._rtt_smoothed)
+                if self._rtt_initialized
+                else self._rtt_initial
+            ),
+            K_GRANULARITY,
         )
         packet_threshold = space.largest_acked_packet - K_PACKET_THRESHOLD
         time_threshold = now - loss_delay

--- a/qh3/quic/recovery.py
+++ b/qh3/quic/recovery.py
@@ -509,7 +509,8 @@ class QuicPacketRecovery:
                 packet = space.sent_packets.pop(packet_number)
                 if packet.is_ack_eliciting:
                     is_ack_eliciting = True
-                    space.ack_eliciting_in_flight -= 1
+                    if not packet.is_pmtu_probe:
+                        space.ack_eliciting_in_flight -= 1
                 if packet.in_flight:
                     self._cc.on_packet_acked(packet)
                 largest_newly_acked = packet_number
@@ -586,10 +587,14 @@ class QuicPacketRecovery:
     def on_packet_sent(self, packet: QuicSentPacket, space: QuicPacketSpace) -> None:
         space.sent_packets[packet.packet_number] = packet
 
-        if packet.is_ack_eliciting:
+        # RFC 9000 14.4: PMTU probes have their own probe
+        # timer and MUST NOT anchor the standard PTO / loss-detection timer.
+        # We exclude them from ack_eliciting_in_flight bookkeeping so they
+        # neither arm PTO nor inflate _pto_count on probe loss.
+        if packet.is_ack_eliciting and not packet.is_pmtu_probe:
             space.ack_eliciting_in_flight += 1
         if packet.in_flight:
-            if packet.is_ack_eliciting:
+            if packet.is_ack_eliciting and not packet.is_pmtu_probe:
                 self._time_of_last_sent_ack_eliciting_packet = packet.sent_time
                 space.time_of_last_ack_eliciting_packet = packet.sent_time
 
@@ -721,9 +726,16 @@ class QuicPacketRecovery:
             del space.sent_packets[packet.packet_number]
 
             if packet.in_flight:
-                lost_packets_cc.append(packet)
+                if packet.is_pmtu_probe:
+                    # RFC 9000 14.4: loss of a PMTU probe MUST NOT trigger
+                    # a congestion control reaction. Reclaim bytes_in_flight
+                    # directly so the connection is not wedged, but skip the
+                    # congestion controller and persistent-congestion logic.
+                    self._cc.bytes_in_flight -= packet.sent_bytes
+                else:
+                    lost_packets_cc.append(packet)
 
-            if packet.is_ack_eliciting:
+            if packet.is_ack_eliciting and not packet.is_pmtu_probe:
                 space.ack_eliciting_in_flight -= 1
 
             if self._quic_logger is not None:
@@ -800,7 +812,7 @@ class QuicPacketRecovery:
             if packet.in_flight:
                 rescheduled_cc.append(packet)
 
-            if packet.is_ack_eliciting:
+            if packet.is_ack_eliciting and not packet.is_pmtu_probe:
                 space.ack_eliciting_in_flight -= 1
 
             # trigger callbacks (so stream senders re-enqueue stream data)

--- a/qh3/quic/recovery.py
+++ b/qh3/quic/recovery.py
@@ -46,6 +46,9 @@ class QuicPacketSpace:
         self.largest_acked_packet = 0
         self.loss_time: float | None = None
         self.sent_packets: dict[int, QuicSentPacket] = {}
+        # RFC 9002 6.2.1: per-PN-space time of last sent ack-eliciting packet,
+        # used as the reference for PTO computation.
+        self.time_of_last_ack_eliciting_packet: float = 0.0
 
 
 class QuicCongestionControl:
@@ -158,6 +161,18 @@ class QuicCongestionControl:
         for packet in packets:
             self.bytes_in_flight -= packet.sent_bytes
 
+    def on_packets_rescheduled(self, packets: Iterable[QuicSentPacket]) -> None:
+        """
+        Mirror of on_packets_lost, but without congestion-control reduction.
+        Used by PTO probes (RFC 9002 6.2.4): a PTO timer expiration MUST NOT
+        cause prior unacknowledged packets to be marked as lost. We still
+        reclaim bytes_in_flight so the application is allowed to retransmit
+        the data on a fresh packet without being blocked by the congestion
+        window.
+        """
+        for packet in packets:
+            self.bytes_in_flight -= packet.sent_bytes
+
     def on_packets_lost(self, packets: Iterable[QuicSentPacket], now: float) -> None:
         lost_largest_time = 0.0
         for packet in packets:
@@ -192,6 +207,31 @@ class QuicCongestionControl:
         ):
             self.ssthresh = self.congestion_window
 
+    def on_persistent_congestion(self, now: float) -> None:
+        """
+        RFC 9002 7.6: on persistent congestion the sender's cwnd is
+        collapsed to the minimum window and slow-start state is reset
+        so the controller re-probes capacity.
+
+        Set ``_congestion_recovery_start_time`` to ``now`` (the time of
+        the collapse), not 0.0. Otherwise, the very next packet declared
+        lost (e.g. a probe sent just after collapse) passes the
+        ``lost_largest_time > _congestion_recovery_start_time`` guard in
+        ``on_packets_lost`` and pins ``ssthresh = MINIMUM_WINDOW``,
+        terminating the new slow-start phase that this collapse was
+        meant to start.
+        """
+        self._congestion_recovery_start_time = now
+        self.congestion_window = self._max_datagram_size * K_MINIMUM_WINDOW
+        self.ssthresh = None
+        self._first_slow_start = True
+        self._starting_congestion_avoidance = False
+        self._K = 0.0
+        self._W_max = self.congestion_window
+        self._W_est = 0
+        self._cwnd_epoch = 0
+        self._t_epoch = 0.0
+
 
 class QuicPacketRecovery:
     """
@@ -223,6 +263,11 @@ class QuicPacketRecovery:
         self._rtt_initial = initial_rtt
         self._rtt_initialized = False
         self._rtt_latest = 0.0
+        # RFC 9002 6.1.2: loss_delay uses the raw latest_rtt sample,
+        # i.e. the last RTT measurement not adjusted for ack delay.
+        # We retain it separately because `rtt_latest above is reduced
+        # by ack_delay for SRTT computation.
+        self._rtt_latest_raw = 0.0
         self._rtt_min = math.inf
         self._rtt_smoothed = 0.0
         self._rtt_variance = 0.0
@@ -264,15 +309,24 @@ class QuicPacketRecovery:
         if loss_space is not None:
             return loss_space.loss_time
 
-        # packet timer
-        if (
-            not self.peer_completed_address_validation
-            or sum(space.ack_eliciting_in_flight for space in self.spaces) > 0
-        ):
+        # PTO timer (RFC 9002 6.2.1): if address validation is incomplete,
+        # arm using the time of the last ack-eliciting packet sent across
+        # any space; otherwise pick the earliest per-space last-sent time
+        # among spaces that have ack-eliciting packets in flight.
+        if not self.peer_completed_address_validation:
             timeout = self.get_probe_timeout() * (2**self._pto_count)
             return self._time_of_last_sent_ack_eliciting_packet + timeout
 
-        return None
+        earliest: float | None = None
+        for space in self.spaces:
+            if space.ack_eliciting_in_flight > 0:
+                t = space.time_of_last_ack_eliciting_packet
+                if earliest is None or t < earliest:
+                    earliest = t
+        if earliest is None:
+            return None
+        timeout = self.get_probe_timeout() * (2**self._pto_count)
+        return earliest + timeout
 
     def get_probe_timeout(self) -> float:
         if not self._rtt_initialized:
@@ -283,15 +337,40 @@ class QuicPacketRecovery:
             + self.max_ack_delay
         )
 
+    def reset_for_new_path(self) -> None:
+        """
+        RFC 9000 9.4 / RFC 9002 5.1: when a path is changed, RTT samples
+        from the prior path are no longer representative. ``min_rtt`` in
+        particular MUST be reset because the new path may have higher
+        latency, and a stale ``min_rtt`` would cause spurious loss
+        declarations (since loss_delay scales with max(latest_rtt,
+        smoothed_rtt) but min_rtt feeds the ack-delay floor in
+        ``on_ack_received``). We additionally reset the smoothed RTT so a
+        fresh sample is taken on the new path.
+        """
+        self._rtt_initialized = False
+        self._rtt_latest = 0.0
+        self._rtt_latest_raw = 0.0
+        self._rtt_min = math.inf
+        self._rtt_smoothed = 0.0
+        self._rtt_variance = 0.0
+
     def on_ack_received(
         self,
         space: QuicPacketSpace,
         ack_rangeset: RangeSet,
         ack_delay: float,
         now: float,
+        reset_pto_count: bool = True,
     ) -> None:
         """
         Update metrics as the result of an ACK being received.
+
+        ``reset_pto_count`` MUST be False when the caller is a client
+        processing an ACK in the Initial packet space and the server has
+        not yet been confirmed to have validated the client's address
+        (RFC 9002 6.2.1). Resetting in that case would prematurely
+        clear the PTO backoff and let a stuck handshake under-probe.
         """
         is_ack_eliciting = False
         largest_acked = ack_rangeset.bounds()[1] - 1
@@ -334,6 +413,10 @@ class QuicPacketRecovery:
 
             # update RTT estimate, which cannot be < 1 ms
             self._rtt_latest = max(latest_rtt, 0.001)
+            # RFC 9002 6.1.2 keeps the *raw* sample (pre ack-delay
+            # subtraction) so the loss-detection time threshold is not
+            # artificially shortened for slow peers.
+            self._rtt_latest_raw = self._rtt_latest
             if self._rtt_latest < self._rtt_min:
                 self._rtt_min = self._rtt_latest
             if self._rtt_latest >= self._rtt_min + ack_delay:
@@ -364,7 +447,8 @@ class QuicPacketRecovery:
         self._detect_loss(space, now=now)
 
         # reset PTO count
-        self._pto_count = 0
+        if reset_pto_count:
+            self._pto_count = 0
 
         if self._quic_logger is not None:
             self._log_metrics_updated(log_rtt=log_rtt)
@@ -386,6 +470,7 @@ class QuicPacketRecovery:
         if packet.in_flight:
             if packet.is_ack_eliciting:
                 self._time_of_last_sent_ack_eliciting_packet = packet.sent_time
+                space.time_of_last_ack_eliciting_packet = packet.sent_time
 
             # add packet to bytes in flight
             self._cc.on_packet_sent(packet)
@@ -395,17 +480,16 @@ class QuicPacketRecovery:
 
     def reschedule_data(self, now: float) -> None:
         """
-        Schedule some data for retransmission.
+        Schedule some data for retransmission upon PTO expiry.
 
-        Per RFC 9002 6.2.4, on PTO expiration the sender MUST send one or two
-        ack-eliciting packets. If application data is in flight, we declare
-        the oldest in-flight packets as lost so their stream data is
-        retransmitted in the same write cycle. This ensures that PTO
-        exponential backoff functions correctly: if the retransmission also
-        fails to elicit an ACK, _pto_count remains elevated and the next PTO
-        interval doubles. Without this, a small PING probe could be ACK'd
-        (resetting _pto_count to 0) while the larger retransmission packet is
-        persistently lost, defeating backoff entirely.
+        Per RFC 9002 6.2.4, on PTO the sender MUST send one or two
+        ack-eliciting packets. A PTO event MUST NOT mark prior packets as
+        lost or trigger a congestion-control reduction. Here we requeue
+        outstanding CRYPTO (or up to two oldest application data packets)
+        so their content is included with the probe; the bytes are
+        reclaimed via on_packets_rescheduled rather than on_packets_lost
+        to avoid an unwarranted cwnd reduction. If nothing was rescheduled
+        the caller emits a PING frame as the ack-eliciting probe.
         """
         # if there is any outstanding CRYPTO, retransmit it
         crypto_scheduled = False
@@ -414,14 +498,13 @@ class QuicPacketRecovery:
                 filter(lambda i: i.is_crypto_packet, space.sent_packets.values())
             )
             if packets:
-                self._on_packets_lost(packets, space=space, now=now)
+                self._on_packets_rescheduled(packets, space=space, now=now)
                 crypto_scheduled = True
         if crypto_scheduled and self._logger is not None:
             self._logger.debug("Scheduled CRYPTO data for retransmission")
 
-        # Reschedule oldest in-flight application data (up to 2 packets) so
-        # it is retransmitted with the probe rather than waiting an extra RTT
-        # for loss detection after the PING ACK.
+        # Reschedule oldest in-flight application data (up to 2 packets)
+        # so it is sent in the same write cycle as the PTO probe.
         app_rescheduled = False
         if not crypto_scheduled:
             for space in self.spaces:
@@ -435,7 +518,7 @@ class QuicPacketRecovery:
                         if len(to_reschedule) >= 2:
                             break
                 if to_reschedule:
-                    self._on_packets_lost(to_reschedule, space=space, now=now)
+                    self._on_packets_rescheduled(to_reschedule, space=space, now=now)
                     app_rescheduled = True
 
         # If no data was rescheduled, send a PING as the ack-eliciting probe
@@ -446,10 +529,14 @@ class QuicPacketRecovery:
         """
         Check whether any packets should be declared lost.
         """
+        # RFC 9002 6.1.2: loss_delay = kTimeThreshold * max(latest_rtt,
+        # smoothed_rtt). latest_rtt here is the most recent raw
+        # RTT sample (without the ack-delay subtraction applied to the
+        # SRTT-input _rtt_latest).
         loss_delay = max(
             K_TIME_THRESHOLD
             * (
-                max(self._rtt_latest, self._rtt_smoothed)
+                max(self._rtt_latest_raw, self._rtt_smoothed)
                 if self._rtt_initialized
                 else self._rtt_initial
             ),
@@ -542,5 +629,66 @@ class QuicPacketRecovery:
                 congestion_window=self._cc.congestion_window,
                 smoothed_rtt=self._rtt_smoothed,
             )
+
+            # RFC 9002 7.6: detect persistent congestion. If at least two
+            # ack-eliciting packets sent over a duration longer than
+            # persistent_congestion_duration are lost, and an RTT sample
+            # has been obtained on this connection (so peer liveness is
+            # established), collapse the congestion window.
+            if self._rtt_initialized:
+                eliciting = [p for p in lost_packets_cc if p.is_ack_eliciting]
+                if len(eliciting) >= 2:
+                    pc_duration = (
+                        self._rtt_smoothed
+                        + max(4 * self._rtt_variance, K_GRANULARITY)
+                        + self.max_ack_delay
+                    ) * 3  # kPersistentCongestionThreshold
+                    span = max(p.sent_time for p in eliciting) - min(
+                        p.sent_time for p in eliciting
+                    )
+                    if span > pc_duration:
+                        if self._logger is not None:
+                            self._logger.debug(
+                                "Persistent congestion detected (span=%.3fs > %.3fs); "
+                                "collapsing cwnd",
+                                span,
+                                pc_duration,
+                            )
+                        self._cc.on_persistent_congestion(now)
+                        self._pacer.update_rate(
+                            congestion_window=self._cc.congestion_window,
+                            smoothed_rtt=self._rtt_smoothed,
+                        )
+            if self._quic_logger is not None:
+                self._log_metrics_updated()
+
+    def _on_packets_rescheduled(
+        self, packets: Iterable[QuicSentPacket], space: QuicPacketSpace, now: float
+    ) -> None:
+        """
+        Requeue the contents of in-flight packets without declaring loss.
+        Used by PTO probes (RFC 9002 6.2.4): the packet is removed from
+        sent_packets and its delivery_handlers fire LOST so the stream
+        sender re-enqueues the data, but congestion control is NOT informed
+        and bytes_in_flight is reclaimed without applying a reduction.
+        """
+        rescheduled_cc: list[QuicSentPacket] = []
+        for packet in packets:
+            del space.sent_packets[packet.packet_number]
+
+            if packet.in_flight:
+                rescheduled_cc.append(packet)
+
+            if packet.is_ack_eliciting:
+                space.ack_eliciting_in_flight -= 1
+
+            # trigger callbacks (so stream senders re-enqueue stream data)
+            dh = packet.delivery_handlers
+            if dh is not None:
+                for handler, args in dh:
+                    handler(QuicDeliveryState.LOST, *args)
+
+        if rescheduled_cc:
+            self._cc.on_packets_rescheduled(rescheduled_cc)
             if self._quic_logger is not None:
                 self._log_metrics_updated()

--- a/qh3/quic/recovery.py
+++ b/qh3/quic/recovery.py
@@ -24,6 +24,14 @@ K_CUBIC_C = 0.4
 K_CUBIC_LOSS_REDUCTION_FACTOR = 0.7
 K_CUBIC_MAX_IDLE_TIME = 2.0  # seconds
 
+# HyStart++ constants (RFC 9406 4.2)
+K_HYSTART_MIN_RTT_THRESH = 0.004  # 4 ms
+K_HYSTART_MAX_RTT_THRESH = 0.016  # 16 ms
+K_HYSTART_MIN_RTT_DIVISOR = 8
+K_HYSTART_N_RTT_SAMPLE = 8
+K_HYSTART_CSS_GROWTH_DIVISOR = 4
+K_HYSTART_CSS_ROUNDS = 5
+
 
 def _cubic_root(x: float) -> float:
     if x < 0:
@@ -76,6 +84,18 @@ class QuicCongestionControl:
         self._cwnd_epoch: int = 0
         self._t_epoch: float = 0.0
 
+        # HyStart++ state (RFC 9406). Enabled by default per spec
+        # recommendation for slow-start exit detection.
+        self.hystart_enabled: bool = True
+        self._hystart_in_css: bool = False
+        self._hystart_css_round: int = 0
+        self._hystart_css_baseline_min_rtt: float = math.inf
+        self._hystart_last_round_min_rtt: float = math.inf
+        self._hystart_current_round_min_rtt: float = math.inf
+        self._hystart_rtt_sample_count: int = 0
+        self._hystart_window_end: int | None = None
+        self._hystart_largest_sent_pn: int = -1
+
     def _W_cubic(self, t: float) -> int:
         W_max_segments = self._W_max / self._max_datagram_size
         target_segments = K_CUBIC_C * (t - self._K) ** 3 + W_max_segments
@@ -91,6 +111,21 @@ class QuicCongestionControl:
         self._W_est = 0
         self._cwnd_epoch = 0
         self._t_epoch = 0.0
+        self._hystart_reset()
+
+    def _hystart_reset(self) -> None:
+        """
+        Reset HyStart++ slow-start exit detector. Called when entering a
+        fresh slow-start phase: at construction, after idle restart, and
+        after persistent congestion collapse.
+        """
+        self._hystart_in_css = False
+        self._hystart_css_round = 0
+        self._hystart_css_baseline_min_rtt = math.inf
+        self._hystart_last_round_min_rtt = math.inf
+        self._hystart_current_round_min_rtt = math.inf
+        self._hystart_rtt_sample_count = 0
+        self._hystart_window_end = None
 
     def _start_epoch(self, now: float) -> None:
         self._t_epoch = now
@@ -104,9 +139,35 @@ class QuicCongestionControl:
         self.bytes_in_flight -= packet.sent_bytes
         self._last_ack = packet.sent_time
 
+        # HyStart++ round tracking (RFC 9406 4.3): a round ends when an
+        # ACK is received for a packet whose number is at or above the
+        # window-end PN recorded at the start of the round.
+        if (
+            self.hystart_enabled
+            and self.ssthresh is None
+            and self._hystart_window_end is not None
+            and packet.packet_number >= self._hystart_window_end
+        ):
+            self._hystart_last_round_min_rtt = self._hystart_current_round_min_rtt
+            self._hystart_current_round_min_rtt = math.inf
+            self._hystart_rtt_sample_count = 0
+            self._hystart_window_end = self._hystart_largest_sent_pn + 1
+            if self._hystart_in_css:
+                self._hystart_css_round += 1
+                if self._hystart_css_round >= K_HYSTART_CSS_ROUNDS:
+                    # Conservative slow start exhausted -> exit to CA.
+                    self.ssthresh = self.congestion_window
+                    self._hystart_in_css = False
+
         if self.ssthresh is None or self.congestion_window < self.ssthresh:
             # slow start
-            self.congestion_window += packet.sent_bytes
+            if self._hystart_in_css:
+                # Conservative Slow Start: dampened growth (RFC 9406 4.3).
+                self.congestion_window += (
+                    packet.sent_bytes // K_HYSTART_CSS_GROWTH_DIVISOR
+                )
+            else:
+                self.congestion_window += packet.sent_bytes
         else:
             # congestion avoidance
             if self._first_slow_start and not self._starting_congestion_avoidance:
@@ -151,6 +212,16 @@ class QuicCongestionControl:
 
     def on_packet_sent(self, packet: QuicSentPacket) -> None:
         self.bytes_in_flight += packet.sent_bytes
+        # Track largest sent PN and bootstrap the HyStart++ round window
+        # on the first packet sent during slow start.
+        if packet.packet_number > self._hystart_largest_sent_pn:
+            self._hystart_largest_sent_pn = packet.packet_number
+        if (
+            self.hystart_enabled
+            and self.ssthresh is None
+            and self._hystart_window_end is None
+        ):
+            self._hystart_window_end = packet.packet_number
         # reset cwnd after prolonged idle
         if self._last_ack > 0.0:
             elapsed_idle = packet.sent_time - self._last_ack
@@ -198,14 +269,63 @@ class QuicCongestionControl:
             )
             self.ssthresh = self.congestion_window
             self._starting_congestion_avoidance = True
+            # RFC 9406 4.2: loss/ECN during slow start or CSS sets
+            # ssthresh = cwnd and exits to congestion avoidance. Clear the
+            # HyStart++ CSS flag so a stale value can't influence growth
+            # if the connection later re-enters slow start (e.g. after
+            # idle resume)
+            self._hystart_in_css = False
 
     def on_rtt_measurement(self, latest_rtt: float, now: float) -> None:
         self._rtt = latest_rtt
-        # check whether we should exit slow start
-        if self.ssthresh is None and self._rtt_monitor.is_rtt_increasing(
-            latest_rtt, now
-        ):
-            self.ssthresh = self.congestion_window
+        if self.ssthresh is not None:
+            return
+
+        if self.hystart_enabled:
+            # HyStart++ slow-start exit detection (RFC 9406 4.3).
+            if latest_rtt < self._hystart_current_round_min_rtt:
+                self._hystart_current_round_min_rtt = latest_rtt
+            self._hystart_rtt_sample_count += 1
+
+            if (
+                self._hystart_rtt_sample_count >= K_HYSTART_N_RTT_SAMPLE
+                and math.isfinite(self._hystart_last_round_min_rtt)
+                and math.isfinite(self._hystart_current_round_min_rtt)
+            ):
+                rtt_thresh = max(
+                    K_HYSTART_MIN_RTT_THRESH,
+                    min(
+                        K_HYSTART_MAX_RTT_THRESH,
+                        self._hystart_last_round_min_rtt / K_HYSTART_MIN_RTT_DIVISOR,
+                    ),
+                )
+                if self._hystart_in_css:
+                    # In CSS: a sustained RTT improvement (current round
+                    # min rtt drops below the CSS baseline) indicates the
+                    # earlier RTT inflation was a false trigger; revert
+                    # to standard slow start (RFC 9406 4.3).
+                    if (
+                        self._hystart_current_round_min_rtt
+                        < self._hystart_css_baseline_min_rtt
+                    ):
+                        self._hystart_in_css = False
+                        self._hystart_css_round = 0
+                        self._hystart_css_baseline_min_rtt = math.inf
+                else:
+                    if (
+                        self._hystart_current_round_min_rtt
+                        >= self._hystart_last_round_min_rtt + rtt_thresh
+                    ):
+                        # Enter Conservative Slow Start.
+                        self._hystart_in_css = True
+                        self._hystart_css_baseline_min_rtt = (
+                            self._hystart_current_round_min_rtt
+                        )
+                        self._hystart_css_round = 0
+        else:
+            # Fallback: legacy RTT-monotonic-rise heuristic.
+            if self._rtt_monitor.is_rtt_increasing(latest_rtt, now):
+                self.ssthresh = self.congestion_window
 
     def on_persistent_congestion(self, now: float) -> None:
         """
@@ -231,6 +351,7 @@ class QuicCongestionControl:
         self._W_est = 0
         self._cwnd_epoch = 0
         self._t_epoch = 0.0
+        self._hystart_reset()
 
 
 class QuicPacketRecovery:

--- a/qh3/quic/stream.py
+++ b/qh3/quic/stream.py
@@ -41,7 +41,12 @@ class QuicStreamReceiver:
 
     def __init__(self, stream_id: int | None, readable: bool) -> None:
         self.highest_offset = 0  # the highest offset ever seen
-        self.is_finished = False
+        # RFC 9000 3.2: a send-only (outgoing unidirectional) stream has
+        # no receive part, so the receiver is "finished" at construction.
+        # Without this, ``QuicStream.is_finished`` would never become
+        # True for outgoing uni streams, leaking entries in
+        # ``QuicConnection._streams`` and ``_streams_finished``.
+        self.is_finished = not readable
         self.stop_pending = False
 
         self._buffer = bytearray()
@@ -130,6 +135,12 @@ class QuicStreamReceiver:
         """
         if self._final_size is not None and final_size != self._final_size:
             raise FinalSizeError("Cannot change final size")
+
+        # RFC 9000 4.5: a RESET_STREAM whose Final Size is smaller than
+        # what has already been received on the stream is a
+        # FINAL_SIZE_ERROR.
+        if final_size < self.highest_offset:
+            raise FinalSizeError("RESET_STREAM final size below already-received data")
 
         # we are done receiving
         self._final_size = final_size

--- a/qh3/quic/stream.py
+++ b/qh3/quic/stream.py
@@ -133,6 +133,8 @@ class QuicStreamReceiver:
 
         # we are done receiving
         self._final_size = final_size
+        if final_size > self.highest_offset:
+            self.highest_offset = final_size
         self.is_finished = True
         return events.StreamReset(error_code=error_code, stream_id=self._stream_id)
 

--- a/qh3/tls.py
+++ b/qh3/tls.py
@@ -196,6 +196,21 @@ class State(IntEnum):
     SERVER_POST_HANDSHAKE = 10
 
 
+# RFC 9001 4.1.3: expected encryption level for each TLS state.
+_STATE_EXPECTED_EPOCH: dict[int, int] = {
+    State.CLIENT_EXPECT_SERVER_HELLO: Epoch.INITIAL,
+    State.CLIENT_EXPECT_ENCRYPTED_EXTENSIONS: Epoch.HANDSHAKE,
+    State.CLIENT_EXPECT_CERTIFICATE_REQUEST_OR_CERTIFICATE: Epoch.HANDSHAKE,
+    State.CLIENT_EXPECT_CERTIFICATE_CERTIFICATE: Epoch.HANDSHAKE,
+    State.CLIENT_EXPECT_CERTIFICATE_VERIFY: Epoch.HANDSHAKE,
+    State.CLIENT_EXPECT_FINISHED: Epoch.HANDSHAKE,
+    State.CLIENT_POST_HANDSHAKE: Epoch.ONE_RTT,
+    State.SERVER_EXPECT_CLIENT_HELLO: Epoch.INITIAL,
+    State.SERVER_EXPECT_FINISHED: Epoch.HANDSHAKE,
+    State.SERVER_POST_HANDSHAKE: Epoch.ONE_RTT,
+}
+
+
 class HKDFExpand:
     def __init__(
         self,
@@ -1739,7 +1754,7 @@ class Context:
         return self._ech_retry_configs
 
     def handle_message(
-        self, input_data: bytes, output_buf: dict[Epoch, Buffer]
+        self, input_data: bytes, output_buf: dict[Epoch, Buffer], epoch: int = -1
     ) -> None:
         if self.state == State.CLIENT_HANDSHAKE_START:
             self._client_send_hello(output_buf[Epoch.INITIAL])
@@ -1760,6 +1775,13 @@ class Context:
             self._receive_buffer = self._receive_buffer[message_length:]
 
             input_buf = Buffer(data=message)
+
+            # Validate that the TLS message arrived at the expected
+            # encryption level (RFC 9001 4.1.3).
+            if epoch >= 0:
+                expected_epoch = _STATE_EXPECTED_EPOCH.get(self.state)
+                if expected_epoch is not None and epoch != expected_epoch:
+                    raise AlertUnexpectedMessage
 
             # client states
 

--- a/src/stream_sender.rs
+++ b/src/stream_sender.rs
@@ -310,6 +310,11 @@ impl QuicStreamSender {
             self.reset_pending = true;
             // Prevent any more data from being sent or re-sent.
             self.buffer_is_empty = true;
+        } else if self.reset_pending {
+            // Allow updating the error code while RESET_STREAM hasn't been
+            // sent yet, so the application can override the default code set
+            // by _handle_stop_sending_frame.
+            self.reset_error_code = Some(error_code);
         }
     }
 

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -482,10 +482,13 @@ class TestHighLevel:
 
         def reset_handler(reader, writer):
             async def serve_one():
-                await reader.read(1)  # consume the trigger byte
-                stream_id = writer.get_extra_info("stream_id")
-                writer.transport.protocol._quic.reset_stream(stream_id, error_code=0x10c)
-                writer.transport.protocol.transmit()
+                try:
+                    await reader.read(1)  # consume the trigger byte
+                    stream_id = writer.get_extra_info("stream_id")
+                    writer.transport.protocol._quic.reset_stream(stream_id, error_code=0x10c)
+                    writer.transport.protocol.transmit()
+                finally:
+                    writer.close()
 
             asyncio.ensure_future(serve_one())
 
@@ -506,9 +509,15 @@ class TestHighLevel:
             ) as client:
                 await client.wait_connected()
                 reader, writer = await client.create_stream()
-                writer.write(b"x")
-                with pytest.raises(ConnectionResetError):
-                    await asyncio.wait_for(reader.read(), timeout=5.0)
+                try:
+                    writer.write(b"x")
+                    with pytest.raises(ConnectionResetError):
+                        await asyncio.wait_for(reader.read(), timeout=5.0)
+                finally:
+                    # Explicitly close the writer so asyncio's
+                    # StreamWriter.__del__ does not run during GC and
+                    # surface an unraisable warning under Python 3.14.
+                    writer.close()
         finally:
             server.close()
 
@@ -520,10 +529,13 @@ class TestHighLevel:
 
         def stop_handler(reader, writer):
             async def serve_one():
-                await reader.read(1)
-                stream_id = writer.get_extra_info("stream_id")
-                writer.transport.protocol._quic.stop_stream(stream_id, error_code=0x10c)
-                writer.transport.protocol.transmit()
+                try:
+                    await reader.read(1)
+                    stream_id = writer.get_extra_info("stream_id")
+                    writer.transport.protocol._quic.stop_stream(stream_id, error_code=0x10c)
+                    writer.transport.protocol.transmit()
+                finally:
+                    writer.close()
 
             asyncio.ensure_future(serve_one())
 
@@ -544,9 +556,12 @@ class TestHighLevel:
             ) as client:
                 await client.wait_connected()
                 reader, writer = await client.create_stream()
-                writer.write(b"x")
-                data = await asyncio.wait_for(reader.read(), timeout=5.0)
-                assert data == b""
+                try:
+                    writer.write(b"x")
+                    data = await asyncio.wait_for(reader.read(), timeout=5.0)
+                    assert data == b""
+                finally:
+                    writer.close()
         finally:
             server.close()
 
@@ -560,6 +575,12 @@ class TestQuicStreamAdapter:
         from unittest.mock import MagicMock
 
         protocol = MagicMock()
+        # The adapter inspects sender state before sending FIN; mock both
+        # flags as False so we exercise the active send path.
+        protocol._quic._streams.__getitem__.return_value.sender.is_finished = False
+        protocol._quic._streams.__getitem__.return_value.sender.reset_pending = False
+        protocol._quic._streams.get.return_value.sender.is_finished = False
+        protocol._quic._streams.get.return_value.sender.reset_pending = False
         adapter = QuicStreamAdapter(protocol=protocol, stream_id=0)
         assert not adapter._closing
 
@@ -581,11 +602,46 @@ class TestQuicStreamAdapter:
         from unittest.mock import MagicMock
 
         protocol = MagicMock()
+        protocol._quic._streams.get.return_value.sender.is_finished = False
+        protocol._quic._streams.get.return_value.sender.reset_pending = False
         adapter = QuicStreamAdapter(protocol=protocol, stream_id=4)
 
         adapter.close()
         assert adapter._closing
         protocol._quic.send_stream_data.assert_called_once_with(4, b"", end_stream=True)
+
+    def test_write_eof_skips_after_reset(self):
+        """RFC 9000 3.5: do not attempt to send a FIN once the peer has
+        reset (or we have stop_sending'd) the stream — the underlying
+        sender raises and the asyncio StreamWriter.__del__ would surface
+        the error as a PytestUnraisableExceptionWarning."""
+        from qh3.asyncio.protocol import QuicStreamAdapter
+        from unittest.mock import MagicMock
+
+        protocol = MagicMock()
+        # Simulate sender that has been reset.
+        protocol._quic._streams.get.return_value.sender.is_finished = False
+        protocol._quic._streams.get.return_value.sender.reset_pending = True
+        adapter = QuicStreamAdapter(protocol=protocol, stream_id=0)
+
+        adapter.write_eof()
+        assert adapter._closing  # marks closing for is_closing()
+        protocol._quic.send_stream_data.assert_not_called()
+        protocol._transmit_soon.assert_not_called()
+
+    def test_write_eof_skips_when_stream_gone(self):
+        """If the underlying stream has been removed from the connection
+        (e.g. after full RESET_STREAM cleanup), write_eof must no-op."""
+        from qh3.asyncio.protocol import QuicStreamAdapter
+        from unittest.mock import MagicMock
+
+        protocol = MagicMock()
+        protocol._quic._streams.get.return_value = None
+        adapter = QuicStreamAdapter(protocol=protocol, stream_id=0)
+
+        adapter.write_eof()
+        assert adapter._closing
+        protocol._quic.send_stream_data.assert_not_called()
 
 
 def _raise_not_implemented(*args, **kwargs):

--- a/tests/test_asyncio.py
+++ b/tests/test_asyncio.py
@@ -474,6 +474,82 @@ class TestHighLevel:
         assert config1.certificate == config3.certificate
         assert config1.certificate == config4.certificate
 
+    @pytest.mark.asyncio
+    async def test_stream_reset_raises_on_reader(self):
+        """RFC 9000 3.5: a peer RESET_STREAM must surface to the
+        asyncio reader as an exception so the application does not hang
+        forever waiting for data that will never arrive."""
+
+        def reset_handler(reader, writer):
+            async def serve_one():
+                await reader.read(1)  # consume the trigger byte
+                stream_id = writer.get_extra_info("stream_id")
+                writer.transport.protocol._quic.reset_stream(stream_id, error_code=0x10c)
+                writer.transport.protocol.transmit()
+
+            asyncio.ensure_future(serve_one())
+
+        server_cfg = QuicConfiguration(is_client=False)
+        server_cfg.load_cert_chain(SERVER_CERTFILE, SERVER_KEYFILE)
+        server = await serve(
+            host="::",
+            port=0,
+            configuration=server_cfg,
+            stream_handler=reset_handler,
+        )
+        try:
+            server_port = server._transport.get_extra_info("sockname")[1]
+            configuration = QuicConfiguration(is_client=True)
+            configuration.load_verify_locations(cafile=SERVER_CACERTFILE)
+            async with connect(
+                self.server_host, server_port, configuration=configuration
+            ) as client:
+                await client.wait_connected()
+                reader, writer = await client.create_stream()
+                writer.write(b"x")
+                with pytest.raises(ConnectionResetError):
+                    await asyncio.wait_for(reader.read(), timeout=5.0)
+        finally:
+            server.close()
+
+    @pytest.mark.asyncio
+    async def test_stop_sending_feeds_eof(self):
+        """RFC 9000 3.5: a peer STOP_SENDING tells us not to send any
+        more on that stream; surface EOF on the corresponding reader so
+        readers do not hang."""
+
+        def stop_handler(reader, writer):
+            async def serve_one():
+                await reader.read(1)
+                stream_id = writer.get_extra_info("stream_id")
+                writer.transport.protocol._quic.stop_stream(stream_id, error_code=0x10c)
+                writer.transport.protocol.transmit()
+
+            asyncio.ensure_future(serve_one())
+
+        server_cfg = QuicConfiguration(is_client=False)
+        server_cfg.load_cert_chain(SERVER_CERTFILE, SERVER_KEYFILE)
+        server = await serve(
+            host="::",
+            port=0,
+            configuration=server_cfg,
+            stream_handler=stop_handler,
+        )
+        try:
+            server_port = server._transport.get_extra_info("sockname")[1]
+            configuration = QuicConfiguration(is_client=True)
+            configuration.load_verify_locations(cafile=SERVER_CACERTFILE)
+            async with connect(
+                self.server_host, server_port, configuration=configuration
+            ) as client:
+                await client.wait_connected()
+                reader, writer = await client.create_stream()
+                writer.write(b"x")
+                data = await asyncio.wait_for(reader.read(), timeout=5.0)
+                assert data == b""
+        finally:
+            server.close()
+
 
 class TestQuicStreamAdapter:
     """Tests for QuicStreamAdapter.write_eof idempotency + close."""

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -486,7 +486,7 @@ class TestQuicConnection:
             client.connect(SERVER_ADDR, now=now)
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [1280, 1280]
-            assert client.get_timer() == 0.2
+            assert client.get_timer() == pytest.approx(0.666)
             self.assertSentPackets(client, [2, 0, 0])
             self.assertEvents(client, [])
 
@@ -496,7 +496,7 @@ class TestQuicConnection:
             server.receive_datagram(items[1][0], CLIENT_ADDR, now=now)
             items = server.datagrams_to_send(now=now)
             assert datagram_sizes(items) == SERVER_INITIAL_DATAGRAM_SIZES
-            assert server.get_timer() == pytest.approx(0.25)
+            assert server.get_timer() == pytest.approx(0.716)
             self.assertSentPackets(server, [1, 2, 0])
             self.assertEvents(server, [events.ProtocolNegotiated])
 
@@ -507,7 +507,7 @@ class TestQuicConnection:
             client.receive_datagram(items[2][0], SERVER_ADDR, now=now)
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == CLIENT_HANDSHAKE_DATAGRAM_SIZES
-            assert client.get_timer() == pytest.approx(0.425)
+            assert client.get_timer() == pytest.approx(0.4)
             self.assertSentPackets(client, [0, 1, 1])
             self.assertEvents(
                 client, [events.ProtocolNegotiated] + HANDSHAKE_COMPLETED_EVENTS
@@ -543,7 +543,7 @@ class TestQuicConnection:
             client.connect(SERVER_ADDR, now=now)
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [1280, 1280]
-            assert client.get_timer() == 0.2
+            assert client.get_timer() == pytest.approx(0.666)
             self.assertSentPackets(client, [2, 0, 0])
             self.assertEvents(client, [])
 
@@ -552,7 +552,7 @@ class TestQuicConnection:
             client.handle_timer(now=now)
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [1280, 1280]
-            assert client.get_timer() == pytest.approx(0.6)
+            assert client.get_timer() == pytest.approx(1.998)
             self.assertSentPackets(client, [2, 0, 0])
             self.assertEvents(client, [])
 
@@ -562,7 +562,7 @@ class TestQuicConnection:
             server.receive_datagram(items[1][0], CLIENT_ADDR, now=now)
             items = server.datagrams_to_send(now=now)
             assert datagram_sizes(items) == SERVER_INITIAL_DATAGRAM_SIZES
-            assert server.get_timer() == pytest.approx(0.45)
+            assert server.get_timer() == pytest.approx(1.382)
             self.assertSentPackets(server, [1, 2, 0])
             self.assertEvents(server, [events.ProtocolNegotiated])
 
@@ -573,7 +573,7 @@ class TestQuicConnection:
             client.receive_datagram(items[2][0], SERVER_ADDR, now=now)
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == CLIENT_HANDSHAKE_DATAGRAM_SIZES
-            assert client.get_timer() == pytest.approx(0.625)
+            assert client.get_timer() == pytest.approx(1.066)
             self.assertSentPackets(client, [0, 1, 1])
             self.assertEvents(
                 client, [events.ProtocolNegotiated] + HANDSHAKE_COMPLETED_EVENTS
@@ -583,7 +583,7 @@ class TestQuicConnection:
             server.receive_datagram(items[0][0], CLIENT_ADDR, now=now)
             items = server.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [229]
-            assert server.get_timer() == pytest.approx(0.625)
+            assert server.get_timer() == pytest.approx(1.091)
             self.assertSentPackets(server, [0, 0, 1])
             self.assertEvents(server, HANDSHAKE_COMPLETED_EVENTS)
 
@@ -592,7 +592,7 @@ class TestQuicConnection:
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [32]
             # idle timeout
-            assert client.get_timer() == pytest.approx(60.4)
+            assert client.get_timer() == pytest.approx(60.866)
             self.assertSentPackets(client, [0, 0, 1])
             self.assertEvents(client, [])
 
@@ -610,7 +610,7 @@ class TestQuicConnection:
             client.connect(SERVER_ADDR, now=now)
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [1280, 1280]
-            assert client.get_timer() == 0.2
+            assert client.get_timer() == pytest.approx(0.666)
             self.assertSentPackets(client, [2, 0, 0])
             self.assertEvents(client, [])
 
@@ -621,7 +621,7 @@ class TestQuicConnection:
             server.receive_datagram(items[1][0], CLIENT_ADDR, now=now)
             items = server.datagrams_to_send(now=now)
             assert datagram_sizes(items) == SERVER_INITIAL_DATAGRAM_SIZES
-            assert server.get_timer() == 0.25
+            assert server.get_timer() == pytest.approx(0.716)
             self.assertSentPackets(server, [1, 2, 0])
             self.assertEvents(server, [events.ProtocolNegotiated])
 
@@ -630,7 +630,7 @@ class TestQuicConnection:
             client.receive_datagram(items[1][0], SERVER_ADDR, now=now)
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [1280, 1280]
-            assert client.get_timer() == pytest.approx(0.3)
+            assert client.get_timer() == pytest.approx(0.766)
             self.assertSentPackets(client, [2, 0, 0])
             self.assertEvents(client, [])
 
@@ -663,7 +663,7 @@ class TestQuicConnection:
             server.receive_datagram(items[0][0], CLIENT_ADDR, now=now)
             items = server.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [229]
-            # self.assertAlmostEqual(server.get_timer(), 0.525)
+            assert server.get_timer() == pytest.approx(0.525)
             self.assertSentPackets(server, [0, 0, 1])
             self.assertEvents(server, HANDSHAKE_COMPLETED_EVENTS)
 
@@ -691,7 +691,7 @@ class TestQuicConnection:
             client.connect(SERVER_ADDR, now=now)
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [1280, 1280]
-            assert client.get_timer() == 0.2
+            assert client.get_timer() == pytest.approx(0.666)
             self.assertSentPackets(client, [2, 0, 0])
             self.assertEvents(client, [])
 
@@ -701,7 +701,7 @@ class TestQuicConnection:
             server.receive_datagram(items[1][0], CLIENT_ADDR, now=now)
             items = server.datagrams_to_send(now=now)
             assert datagram_sizes(items) == SERVER_INITIAL_DATAGRAM_SIZES
-            assert server.get_timer() == 0.25
+            assert server.get_timer() == pytest.approx(0.716)
             self.assertSentPackets(server, [1, 2, 0])
             self.assertEvents(server, [events.ProtocolNegotiated])
 
@@ -710,7 +710,7 @@ class TestQuicConnection:
             client.handle_timer(now=now)
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [1280, 1280]
-            assert client.get_timer() == pytest.approx(0.6)
+            assert client.get_timer() == pytest.approx(1.998)
             self.assertSentPackets(client, [2, 0, 0])
             self.assertEvents(client, [])
 
@@ -720,7 +720,7 @@ class TestQuicConnection:
             server.receive_datagram(items[1][0], CLIENT_ADDR, now=now)
             items = server.datagrams_to_send(now=now)
             assert datagram_sizes(items) == SERVER_INITIAL_DATAGRAM_SIZES
-            assert server.get_timer() == 0.45
+            assert server.get_timer() == pytest.approx(1.382)
             self.assertSentPackets(server, [1, 2, 0])
             self.assertEvents(server, [])
 
@@ -731,8 +731,8 @@ class TestQuicConnection:
             client.receive_datagram(items[2][0], SERVER_ADDR, now=now)
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == CLIENT_HANDSHAKE_DATAGRAM_SIZES
-            assert client.get_timer() >= 0.5
-            assert client.get_timer() <= 0.63
+            assert client.get_timer() >= 1.0
+            assert client.get_timer() <= 1.1
             self.assertSentPackets(client, [0, 1, 1])
             self.assertEvents(
                 client, [events.ProtocolNegotiated] + HANDSHAKE_COMPLETED_EVENTS
@@ -742,7 +742,7 @@ class TestQuicConnection:
             server.receive_datagram(items[0][0], CLIENT_ADDR, now=now)
             items = server.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [229]
-            assert server.get_timer() == pytest.approx(0.625)
+            assert server.get_timer() == pytest.approx(1.091)
             self.assertSentPackets(server, [0, 0, 1])
             self.assertEvents(server, HANDSHAKE_COMPLETED_EVENTS)
 
@@ -751,7 +751,7 @@ class TestQuicConnection:
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [32]
             # idle timeout
-            assert client.get_timer() == pytest.approx(60.4)
+            assert client.get_timer() == pytest.approx(60.866)
             self.assertSentPackets(client, [0, 0, 1])
             self.assertEvents(client, [])
 
@@ -765,7 +765,7 @@ class TestQuicConnection:
             client.connect(SERVER_ADDR, now=now)
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [1280, 1280]
-            assert client.get_timer() == 0.2
+            assert client.get_timer() == pytest.approx(0.666)
             self.assertSentPackets(client, [2, 0, 0])
             self.assertEvents(client, [])
 
@@ -776,7 +776,7 @@ class TestQuicConnection:
             server.receive_datagram(items[1][0], CLIENT_ADDR, now=now)
             items = server.datagrams_to_send(now=now)
             assert datagram_sizes(items) == SERVER_INITIAL_DATAGRAM_SIZES
-            assert server.get_timer() == 0.25
+            assert server.get_timer() == pytest.approx(0.716)
             self.assertSentPackets(server, [1, 2, 0])
             self.assertEvents(server, [events.ProtocolNegotiated])
 
@@ -786,7 +786,7 @@ class TestQuicConnection:
             client.receive_datagram(items[1][0], SERVER_ADDR, now=now)
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [1280]
-            assert client.get_timer() == pytest.approx(0.325)
+            assert client.get_timer() == pytest.approx(0.3)
             self.assertSentPackets(client, [0, 1, 0])
             self.assertEvents(client, [events.ProtocolNegotiated])
 
@@ -795,7 +795,7 @@ class TestQuicConnection:
             client.handle_timer(now=now)
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [45]
-            assert client.get_timer() == pytest.approx(0.975)
+            assert client.get_timer() == pytest.approx(0.9)
             self.assertSentPackets(client, [0, 2, 0])
             self.assertEvents(client, [])
 
@@ -804,7 +804,7 @@ class TestQuicConnection:
             server.receive_datagram(items[0][0], CLIENT_ADDR, now=now)
             items = server.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [48]
-            assert server.get_timer() == pytest.approx(0.25)
+            assert server.get_timer() == pytest.approx(0.716)
             self.assertSentPackets(server, [0, 3, 0])
             self.assertEvents(server, [])
 
@@ -813,7 +813,7 @@ class TestQuicConnection:
             server.handle_timer(now=now)
             items = server.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [1280, 890]
-            assert server.get_timer() == pytest.approx(0.65)
+            assert server.get_timer() == pytest.approx(2.048)
             self.assertSentPackets(server, [0, 3, 0])
             self.assertEvents(server, [])
 
@@ -823,7 +823,7 @@ class TestQuicConnection:
             client.receive_datagram(items[1][0], SERVER_ADDR, now=now)
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [313]
-            assert client.get_timer() == pytest.approx(0.95)
+            assert client.get_timer() == pytest.approx(1.366)
             self.assertSentPackets(client, [0, 3, 1])
             self.assertEvents(client, HANDSHAKE_COMPLETED_EVENTS)
 
@@ -831,7 +831,7 @@ class TestQuicConnection:
             server.receive_datagram(items[0][0], CLIENT_ADDR, now=now)
             items = server.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [229]
-            assert server.get_timer() == pytest.approx(0.675)
+            assert server.get_timer() == pytest.approx(1.141)
             self.assertSentPackets(server, [0, 0, 1])
             self.assertEvents(server, HANDSHAKE_COMPLETED_EVENTS)
 
@@ -840,7 +840,7 @@ class TestQuicConnection:
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [32]
             # idle timeout
-            assert client.get_timer() == pytest.approx(60.4)
+            assert client.get_timer() == pytest.approx(60.866)
             self.assertSentPackets(client, [0, 0, 1])
             self.assertEvents(client, [])
 
@@ -854,7 +854,7 @@ class TestQuicConnection:
             client.connect(SERVER_ADDR, now=now)
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == [1280, 1280]
-            assert client.get_timer() == 0.2
+            assert client.get_timer() == pytest.approx(0.666)
 
             # server receives INITIAL, sends INITIAL + HANDSHAKE
             now += TICK
@@ -862,7 +862,7 @@ class TestQuicConnection:
             server.receive_datagram(items[1][0], CLIENT_ADDR, now=now)
             items = server.datagrams_to_send(now=now)
             assert datagram_sizes(items) == SERVER_INITIAL_DATAGRAM_SIZES
-            assert server.get_timer() == 0.25
+            assert server.get_timer() == pytest.approx(0.716)
             self.assertSentPackets(server, [1, 2, 0])
             self.assertEvents(server, [events.ProtocolNegotiated])
 
@@ -873,7 +873,7 @@ class TestQuicConnection:
             client.receive_datagram(items[2][0], SERVER_ADDR, now=now)
             items = client.datagrams_to_send(now=now)
             assert datagram_sizes(items) == CLIENT_HANDSHAKE_DATAGRAM_SIZES
-            assert client.get_timer() == pytest.approx(0.425)
+            assert client.get_timer() == pytest.approx(0.4)
             self.assertSentPackets(client, [0, 1, 1])
             self.assertEvents(
                 client, [events.ProtocolNegotiated] + HANDSHAKE_COMPLETED_EVENTS
@@ -1439,6 +1439,10 @@ class TestQuicConnection:
     def test_handle_ack_frame_ecn(self):
         client = create_standalone_client(self)
 
+        # Pretend we have sent a 1-RTT packet so the ACK below is valid
+        # (RFC 9000 19.3.1: ACKs must not acknowledge unsent packets).
+        client._spaces[tls.Epoch.ONE_RTT].packet_number = 1
+
         client._handle_ack_frame(
             client_receive_context(client),
             QuicFrameType.ACK_ECN,
@@ -1499,7 +1503,20 @@ class TestQuicConnection:
             assert cm.value.frame_type == QuicFrameType.CRYPTO
             assert cm.value.reason_phrase == "offset + length cannot exceed 2^62 - 1"
 
-    def test_handle_data_blocked_frame(self):
+    def test_max_ack_delay_deferred_until_handshake_confirmed(self):
+        """RFC 9002 6.2.1: max_ack_delay only applies after the handshake
+        is confirmed. Before then loss-recovery computations MUST use a
+        max_ack_delay of 0."""
+        # Pre-handshake: brand-new client.
+        fresh = create_standalone_client(self)
+        assert fresh._loss.max_ack_delay == 0.0
+
+        # Post-handshake: client_and_server runs handshake to completion.
+        with client_and_server() as (client, server):
+            assert client._loss.max_ack_delay == client._remote_max_ack_delay
+            assert server._loss.max_ack_delay == server._remote_max_ack_delay
+
+
         with client_and_server() as (client, server):
             # client receives DATA_BLOCKED: 12345
             client._handle_data_blocked_frame(
@@ -1507,6 +1524,92 @@ class TestQuicConnection:
                 QuicFrameType.DATA_BLOCKED,
                 Buffer(data=encode_uint_var(12345)),
             )
+
+    def test_stateless_reset_terminates_connection(self):
+        """RFC 9000 10.3: a UDP datagram whose trailing 16 bytes match a
+        known peer stateless reset token MUST terminate the connection."""
+        with client_and_server() as (client, server):
+            token = client._peer_cid.stateless_reset_token
+            assert token is not None and len(token) == 16
+
+            # Synthesize a junk short-header datagram that uses the
+            # client's own host CID as the destination, fills a fake
+            # packet body, and ends with the peer-issued stateless reset
+            # token. AEAD will fail; the connection MUST then detect the
+            # trailing token and terminate.
+            cid = client.host_cid
+            junk = b"\x40" + cid + bytes(64) + token
+            client.receive_datagram(junk, SERVER_ADDR, now=time.time())
+
+            # Drain events to find ConnectionTerminated.
+            terminated = None
+            while True:
+                ev = client.next_event()
+                if ev is None:
+                    break
+                if isinstance(ev, events.ConnectionTerminated):
+                    terminated = ev
+            assert terminated is not None
+            assert terminated.reason_phrase == "Stateless reset"
+
+    def test_path_challenge_datagram_is_padded(self):
+        """RFC 9000 8.2.1: datagrams carrying PATH_CHALLENGE MUST be
+        padded to at least 1200 bytes (subject to anti-amplification).
+        We send enough bytes from the migrated path so anti-amplification
+        does not cap the response below 1200 bytes."""
+        with client_and_server() as (client, server):
+            # client appears to migrate; pump a few full datagrams of
+            # data from the new address so the server has > 400 bytes
+            # received and anti-amplification allows a >=1200 byte reply.
+            client.send_stream_data(0, b"x" * 4000)
+            for data, _addr in client.datagrams_to_send(now=time.time()):
+                server.receive_datagram(data, ("1.2.3.4", 2345), now=time.time())
+
+            datagrams = server.datagrams_to_send(now=time.time())
+            new_path_dgrams = [
+                d for d, addr in datagrams if addr == ("1.2.3.4", 2345)
+            ]
+            assert new_path_dgrams, "server did not send to migrated path"
+            # The PATH_CHALLENGE-carrying datagram must be padded.
+            assert any(len(d) >= 1200 for d in new_path_dgrams), [
+                len(d) for d in new_path_dgrams
+            ]
+
+    def test_connection_close_retransmits_on_repeated_input(self):
+        """RFC 9000 10.2.1: an endpoint in CLOSING state SHOULD send a
+        packet containing a CONNECTION_CLOSE frame in response to any
+        UDP datagram it receives, subject to rate limiting."""
+        with client_and_server() as (client, server):
+            # Server initiates close.
+            server.close(error_code=0x0)
+            close_dgrams = list(server.datagrams_to_send(now=time.time()))
+            assert close_dgrams, "server did not emit CONNECTION_CLOSE"
+            close_pkt = close_dgrams[0][0]
+
+            # Loopback the server's own CC bytes back to it; it can't
+            # decrypt them but the receive accounting still drives the
+            # exponential-backoff retransmit logic.
+            retransmits = 0
+            for _ in range(64):
+                server.receive_datagram(close_pkt, SERVER_ADDR, now=time.time())
+                emitted = list(server.datagrams_to_send(now=time.time()))
+                retransmits += len(emitted)
+            assert retransmits >= 4, (
+                f"expected at least 4 CONNECTION_CLOSE retransmissions, "
+                f"got {retransmits}"
+            )
+
+    def test_data_blocked_frame_at_limit_bumps_max_data(self):
+        """RFC 9000 4.1: a DATA_BLOCKED at our advertised connection-level
+        limit MUST cause us to extend credit so the peer can make progress."""
+        with client_and_server() as (client, server):
+            old_limit = client._local_max_data.value
+            client._handle_data_blocked_frame(
+                client_receive_context(client),
+                QuicFrameType.DATA_BLOCKED,
+                Buffer(data=encode_uint_var(old_limit)),
+            )
+            assert client._local_max_data.value == 2 * old_limit
 
     def test_handle_datagram_frame(self):
         client = create_standalone_client(self, max_datagram_frame_size=6)
@@ -2106,11 +2209,14 @@ class TestQuicConnection:
 
     def test_handle_reset_stream_frame_twice(self):
         stream_id = 3
+        # RFC 9000 4.5: RESET_STREAM Final Size MUST NOT be less than
+        # the bytes already received on the stream; the server has sent
+        # 5 bytes ("hello") below, so we declare final_size=5.
         reset_stream_data = (
             encode_uint_var(QuicFrameType.RESET_STREAM)
             + encode_uint_var(stream_id)
             + encode_uint_var(QuicErrorCode.INTERNAL_ERROR)
-            + encode_uint_var(0)
+            + encode_uint_var(5)
         )
         with client_and_server() as (client, server):
             # server creates unidirectional stream
@@ -2374,6 +2480,29 @@ class TestQuicConnection:
                 QuicFrameType.STREAM_DATA_BLOCKED,
                 Buffer(data=b"\x00\x01"),
             )
+
+    def test_stream_data_blocked_at_limit_bumps_max_stream_data(self):
+        """RFC 9000 4.1: STREAM_DATA_BLOCKED at the advertised stream
+        limit MUST grant more credit on a live stream."""
+        with client_and_server() as (client, server):
+            # peer (server) creates bidirectional stream 1 -> client receives.
+            # Easier: have the server send some data, which auto-creates
+            # stream 1 on the client with max_stream_data_local set.
+            server.send_stream_data(stream_id=1, data=b"hi")
+            roundtrip(server, client)
+            stream = client._streams[1]
+            old_limit = stream.max_stream_data_local
+            assert old_limit > 0
+
+            buf = Buffer(
+                data=encode_uint_var(1) + encode_uint_var(old_limit)
+            )
+            client._handle_stream_data_blocked_frame(
+                client_receive_context(client),
+                QuicFrameType.STREAM_DATA_BLOCKED,
+                buf,
+            )
+            assert stream.max_stream_data_local == 2 * old_limit
 
     def test_handle_stream_data_blocked_frame_send_only(self):
         with client_and_server() as (client, server):

--- a/tests/test_crypto_v1.py
+++ b/tests/test_crypto_v1.py
@@ -408,6 +408,84 @@ class TestCrypto:
             self.create_hp(key=bytes(33))
         assert str(cm.value) == "Given key is not valid for chosen algorithm"
 
+    def test_previous_recv_decrypts_reordered_packet(self):
+        """
+        After a local key update, a packet that was sent before the rotation
+        must still decrypt via the retained previous receive context, and
+        doing so must NOT trigger another rotation on the receiver.
+
+        See RFC 9001 6.5.
+        """
+        pair1 = self.create_crypto(is_client=True)
+        pair2 = self.create_crypto(is_client=False)
+
+        def make_packet(key_phase, packet_number):
+            buf = Buffer(capacity=100)
+            buf.push_uint8(PACKET_FIXED_BIT | key_phase << 2 | 1)
+            buf.push_bytes(binascii.unhexlify("8394c8f03e515708"))
+            buf.push_uint16(packet_number)
+            return buf.data, b"\x00\x01\x02\x03"
+
+        # Initial roundtrip in phase 0.
+        plain_header_old, plain_payload_old = make_packet(
+            key_phase=pair1.key_phase, packet_number=0
+        )
+        encrypted_old = pair1.encrypt_packet(
+            plain_header_old, plain_payload_old, 0
+        )
+        recov_header, recov_payload, recov_pn = pair2.decrypt_packet(
+            encrypted_old, len(plain_header_old) - 2, 0
+        )
+        assert recov_header == plain_header_old
+        assert recov_payload == plain_payload_old
+        assert recov_pn == 0
+        assert pair2.key_phase == 0
+
+        # Pair 1 rotates and sends a fresh packet under phase 1; pair 2
+        # picks up the rotation and snapshots its phase-0 recv context.
+        pair1.update_key()
+        plain_header_new, plain_payload_new = make_packet(
+            key_phase=pair1.key_phase, packet_number=1
+        )
+        encrypted_new = pair1.encrypt_packet(
+            plain_header_new, plain_payload_new, 1
+        )
+        recov_header, recov_payload, recov_pn = pair2.decrypt_packet(
+            encrypted_new, len(plain_header_new) - 2, 1
+        )
+        assert recov_header == plain_header_new
+        assert recov_pn == 1
+        assert pair2.key_phase == 1
+        assert pair2._previous_recv is not None
+
+        # Connection layer would normally schedule expiry; emulate it.
+        pair2.retain_previous_keys(expires_at=999.0)
+
+        # Now a reordered phase-0 packet (sent before pair 1's update) arrives.
+        # It must decrypt via the snapshot WITHOUT toggling key_phase back.
+        plain_header_late, plain_payload_late = make_packet(
+            key_phase=0, packet_number=2
+        )
+        # Re-encrypt under a fresh phase-0 sender to simulate the
+        # in-flight packet that was emitted before the rotation.
+        late_sender = self.create_crypto(is_client=True)
+        encrypted_late = late_sender.encrypt_packet(
+            plain_header_late, plain_payload_late, 2
+        )
+        recov_header, recov_payload, recov_pn = pair2.decrypt_packet(
+            encrypted_late, len(plain_header_late) - 2, 2
+        )
+        assert recov_header == plain_header_late
+        assert recov_payload == plain_payload_late
+        assert recov_pn == 2
+        # Crucially: no spurious rotation back to phase 0.
+        assert pair2.key_phase == 1
+
+        # Snapshot is dropped once the 3*PTO timer expires.
+        pair2.expire_previous_keys(now=999.0)
+        assert pair2._previous_recv is None
+        assert pair2._previous_recv_expires_at is None
+
     def test_decrypt_short_server_packet_too_short(self):
         """Truncated packet must raise CryptoError, not panic."""
         pair = CryptoPair()

--- a/tests/test_h3.py
+++ b/tests/test_h3.py
@@ -1268,6 +1268,190 @@ class TestH3Connection:
             )
             assert h3_transfer(quic_client, h3_server) == []
 
+    def test_grease_after_request_body(self):
+        """Issue #565: GREASE frame after DATA swallows stream_ended."""
+        with h3_client_and_server() as (quic_client, quic_server):
+            h3_client = H3Connection(quic_client)
+            h3_server = H3Connection(quic_server)
+
+            stream_id = quic_client.get_next_available_stream_id()
+            h3_client.send_headers(
+                stream_id=stream_id,
+                headers=[
+                    (b":method", b"POST"),
+                    (b":scheme", b"https"),
+                    (b":authority", b"localhost"),
+                    (b":path", b"/"),
+                    (b"x-foo", b"client"),
+                ],
+                end_stream=False,
+            )
+            h3_client.send_data(
+                stream_id=stream_id, data=b"hello world", end_stream=False
+            )
+            # Send a GREASE frame directly at the QUIC level, ending the stream
+            grease_type = 0x21  # smallest valid GREASE type
+            quic_client.send_stream_data(
+                stream_id=stream_id,
+                data=encode_frame(frame_type=grease_type, frame_data=b"grease"),
+                end_stream=True,
+            )
+
+            events = h3_transfer(quic_client, h3_server)
+            assert events == [
+                HeadersReceived(
+                    headers=[
+                        (b":method", b"POST"),
+                        (b":scheme", b"https"),
+                        (b":authority", b"localhost"),
+                        (b":path", b"/"),
+                        (b"x-foo", b"client"),
+                    ],
+                    stream_id=stream_id,
+                    stream_ended=False,
+                ),
+                DataReceived(data=b"hello world", stream_id=0, stream_ended=False),
+                DataReceived(data=b"", stream_id=0, stream_ended=True),
+            ]
+
+    def test_push_promise_after_response_body(self):
+        """Issue #565: PUSH_PROMISE after DATA swallows stream_ended."""
+        with h3_client_and_server() as (quic_client, quic_server):
+            h3_client = H3Connection(quic_client)
+            h3_server = H3Connection(quic_server)
+
+            stream_id = quic_client.get_next_available_stream_id()
+            h3_client.send_headers(
+                stream_id=stream_id,
+                headers=[
+                    (b":method", b"GET"),
+                    (b":scheme", b"https"),
+                    (b":authority", b"localhost"),
+                    (b":path", b"/test-promise"),
+                ],
+                end_stream=True,
+            )
+
+            h3_transfer(quic_client, h3_server)
+
+            # Server sends response + push promise, then ends stream
+            h3_server.send_headers(
+                stream_id=stream_id,
+                headers=[
+                    (b":status", b"200"),
+                    (b"content-type", b"text/html; charset=utf-8"),
+                ],
+                end_stream=False,
+            )
+            h3_server.send_data(
+                stream_id=stream_id, data=b"html", end_stream=False
+            )
+            h3_server.send_push_promise(
+                stream_id=stream_id,
+                headers=[
+                    (b":method", b"GET"),
+                    (b":scheme", b"https"),
+                    (b":authority", b"localhost"),
+                    (b":path", b"/my/promise"),
+                ],
+            )
+            # End the stream at the QUIC level
+            quic_server.send_stream_data(
+                stream_id=stream_id, data=b"", end_stream=True
+            )
+
+            events = h3_transfer(quic_server, h3_client)
+            assert events == [
+                HeadersReceived(
+                    headers=[
+                        (b":status", b"200"),
+                        (b"content-type", b"text/html; charset=utf-8"),
+                    ],
+                    stream_id=0,
+                    stream_ended=False,
+                ),
+                DataReceived(data=b"html", stream_id=0, stream_ended=False),
+                PushPromiseReceived(
+                    headers=[
+                        (b":method", b"GET"),
+                        (b":scheme", b"https"),
+                        (b":authority", b"localhost"),
+                        (b":path", b"/my/promise"),
+                    ],
+                    push_id=0,
+                    stream_id=stream_id,
+                ),
+                DataReceived(data=b"", stream_id=0, stream_ended=True),
+            ]
+
+    def test_grease_after_trailers(self):
+        """Issue #565: GREASE after trailers - trailers should carry stream_ended."""
+        with h3_client_and_server() as (quic_client, quic_server):
+            h3_client = H3Connection(quic_client)
+            h3_server = H3Connection(quic_server)
+
+            stream_id = quic_client.get_next_available_stream_id()
+            h3_client.send_headers(
+                stream_id=stream_id,
+                headers=[
+                    (b":method", b"GET"),
+                    (b":scheme", b"https"),
+                    (b":authority", b"localhost"),
+                    (b":path", b"/"),
+                ],
+                end_stream=True,
+            )
+            h3_transfer(quic_client, h3_server)
+
+            # Server sends response with trailers, then GREASE at QUIC level
+            h3_server.send_headers(
+                stream_id=stream_id,
+                headers=[
+                    (b":status", b"200"),
+                    (b"content-type", b"text/html; charset=utf-8"),
+                ],
+                end_stream=False,
+            )
+            h3_server.send_data(
+                stream_id=stream_id,
+                data=b"<html><body>hello</body></html>",
+                end_stream=False,
+            )
+            h3_server.send_headers(
+                stream_id=stream_id,
+                headers=[(b"x-some-trailer", b"bar")],
+                end_stream=False,
+            )
+            # Send GREASE frame at QUIC level, ending the stream
+            grease_type = 0x21
+            quic_server.send_stream_data(
+                stream_id=stream_id,
+                data=encode_frame(frame_type=grease_type, frame_data=b"grease"),
+                end_stream=True,
+            )
+
+            events = h3_transfer(quic_server, h3_client)
+            assert events == [
+                HeadersReceived(
+                    headers=[
+                        (b":status", b"200"),
+                        (b"content-type", b"text/html; charset=utf-8"),
+                    ],
+                    stream_id=stream_id,
+                    stream_ended=False,
+                ),
+                DataReceived(
+                    data=b"<html><body>hello</body></html>",
+                    stream_id=stream_id,
+                    stream_ended=False,
+                ),
+                HeadersReceived(
+                    headers=[(b"x-some-trailer", b"bar")],
+                    stream_id=stream_id,
+                    stream_ended=True,
+                ),
+            ]
+
     def test_request_with_trailers(self):
         with h3_client_and_server() as (quic_client, quic_server):
             h3_client = H3Connection(quic_client)

--- a/tests/test_h3.py
+++ b/tests/test_h3.py
@@ -24,10 +24,10 @@ from qh3.h3.connection import (
     validate_response_headers,
     validate_trailers,
 )
-from qh3.h3.events import DataReceived, HeadersReceived, PushPromiseReceived, InformationalHeadersReceived
+from qh3.h3.events import DataReceived, HeadersReceived, PushPromiseReceived, InformationalHeadersReceived, StreamReset as H3StreamReset, StopSending as H3StopSending
 from qh3.h3.exceptions import NoAvailablePushIDError
 from qh3.quic.configuration import QuicConfiguration
-from qh3.quic.events import StreamDataReceived
+from qh3.quic.events import StreamDataReceived, StreamReset as QuicStreamReset, StopSendingReceived
 from qh3.quic.logger import QuicLogger
 
 from .test_connection import client_and_server, transfer
@@ -382,6 +382,106 @@ class TestH3Connection:
                 ErrorCode.H3_STREAM_CREATION_ERROR,
                 "Only one control stream is allowed",
             )
+
+    def test_handle_stream_reset_emits_h3_event(self):
+        """RFC 9114: a peer reset of a request stream surfaces as
+        H3StreamReset to the application."""
+        with h3_client_and_server() as (quic_client, quic_server):
+            h3_client = H3Connection(quic_client)
+            h3_server = H3Connection(quic_server)
+
+            # send headers only (do NOT end stream so server-side state stays)
+            stream_id = quic_client.get_next_available_stream_id()
+            h3_client.send_headers(
+                stream_id=stream_id,
+                headers=[
+                    (b":method", b"POST"),
+                    (b":scheme", b"https"),
+                    (b":authority", b"localhost"),
+                    (b":path", b"/"),
+                ],
+            )
+            transfer(quic_client, quic_server)
+            # drain queued events
+            while quic_server.next_event() is not None:
+                pass
+
+            events = h3_server.handle_event(
+                QuicStreamReset(error_code=0x10c, stream_id=stream_id)
+            )
+            assert events == [
+                H3StreamReset(stream_id=stream_id, error_code=0x10c)
+            ]
+            assert stream_id not in h3_server._blocked_stream_map
+
+    def test_handle_stop_sending_emits_h3_event(self):
+        """RFC 9114: STOP_SENDING on a request stream surfaces as H3StopSending."""
+        with h3_client_and_server() as (quic_client, quic_server):
+            h3_client = H3Connection(quic_client)
+            h3_server = H3Connection(quic_server)
+
+            stream_id = quic_client.get_next_available_stream_id()
+            h3_client.send_headers(
+                stream_id=stream_id,
+                headers=[
+                    (b":method", b"POST"),
+                    (b":scheme", b"https"),
+                    (b":authority", b"localhost"),
+                    (b":path", b"/"),
+                ],
+            )
+            transfer(quic_client, quic_server)
+            while quic_server.next_event() is not None:
+                pass
+
+            events = h3_server.handle_event(
+                StopSendingReceived(error_code=0x10c, stream_id=stream_id)
+            )
+            assert events == [
+                H3StopSending(stream_id=stream_id, error_code=0x10c)
+            ]
+            assert stream_id not in h3_server._blocked_stream_map
+
+    def test_handle_critical_stream_reset_closes_connection(self):
+        """RFC 9114 6.2: a peer reset of a critical stream is fatal."""
+        quic_client = FakeQuicConnection(
+            configuration=QuicConfiguration(is_client=True)
+        )
+        h3_client = H3Connection(quic_client)
+
+        # register the peer (server) control stream
+        h3_client.handle_event(
+            StreamDataReceived(
+                stream_id=3,
+                data=encode_uint_var(StreamType.CONTROL)
+                + encode_frame(FrameType.SETTINGS, encode_settings(DUMMY_SETTINGS)),
+                end_stream=False,
+            )
+        )
+        assert quic_client.closed is None
+
+        # peer resets its control stream
+        h3_client.handle_event(QuicStreamReset(error_code=0, stream_id=3))
+        assert quic_client.closed == (
+            ErrorCode.H3_CLOSED_CRITICAL_STREAM,
+            "Critical stream 3 reset by peer",
+        )
+
+    def test_handle_critical_stream_stop_sending_closes_connection(self):
+        """RFC 9114 6.2: STOP_SENDING on a critical stream is fatal."""
+        quic_client = FakeQuicConnection(
+            configuration=QuicConfiguration(is_client=True)
+        )
+        h3_client = H3Connection(quic_client)
+        local_control = h3_client._local_control_stream_id
+
+        h3_client.handle_event(
+            StopSendingReceived(error_code=0, stream_id=local_control)
+        )
+        assert quic_client.closed == (
+            ErrorCode.H3_CLOSED_CRITICAL_STREAM,
+            f"Critical stream {local_control} stop-sending by peer",
+        )
 
     def test_handle_push_frame_wrong_frame_type(self):
         """

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -316,6 +316,16 @@ class TestParams:
         push_quic_transport_parameters(buf, params)
         assert buf.data == data
 
+    def test_pull_rejects_duplicate_param_id(self):
+        # RFC 9000 7.4: a parameter received twice MUST be treated as
+        # TRANSPORT_PARAMETER_ERROR. Send max_idle_timeout (id=0x01)
+        # twice and expect a ValueError.
+        data = binascii.unhexlify("01026710" "01026710")
+        buf = Buffer(data=data)
+        with pytest.raises(ValueError) as cm:
+            pull_quic_transport_parameters(buf)
+        assert "Duplicate transport parameter" in str(cm.value)
+
 
 class TestPrettyProtocolVersion:
     """Tests for pretty_protocol_version."""

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -388,6 +388,184 @@ class TestQuicPacketRecovery:
         assert cc.ssthresh is None  # slow-start still alive
 
 
+class TestPmtuProbeLossDetection:
+    """RFC 9000 14.4: PMTU probe loss MUST NOT trigger CC reaction."""
+
+    def setup_method(self):
+        self.INITIAL_SPACE = QuicPacketSpace()
+        self.HANDSHAKE_SPACE = QuicPacketSpace()
+        self.ONE_RTT_SPACE = QuicPacketSpace()
+        self.recovery = QuicPacketRecovery(
+            initial_rtt=0.1,
+            peer_completed_address_validation=True,
+            send_probe=send_probe,
+            max_datagram_size=1280,
+        )
+        self.recovery.spaces = [
+            self.INITIAL_SPACE,
+            self.HANDSHAKE_SPACE,
+            self.ONE_RTT_SPACE,
+        ]
+
+    def _probe_packet(self, pn: int, sent_time: float, size: int = 1452):
+        pkt = QuicSentPacket(
+            epoch=tls.Epoch.ONE_RTT,
+            in_flight=True,
+            is_ack_eliciting=True,
+            is_crypto_packet=False,
+            packet_number=pn,
+            packet_type=QuicPacketType.ONE_RTT,
+            sent_bytes=size,
+            sent_time=sent_time,
+            is_pmtu_probe=True,
+        )
+        return pkt
+
+    def test_pmtu_probe_loss_does_not_reduce_cwnd(self):
+        cc = self.recovery._cc
+        baseline_cwnd = cc.congestion_window
+        assert cc.ssthresh is None  # slow-start
+
+        probe = self._probe_packet(pn=0, sent_time=0.0)
+        self.recovery.on_packet_sent(probe, self.ONE_RTT_SPACE)
+        assert cc.bytes_in_flight == 1452
+
+        # Probe declared lost, must NOT trigger congestion reaction.
+        self.recovery._on_packets_lost(
+            [probe], space=self.ONE_RTT_SPACE, now=1.0
+        )
+        assert cc.bytes_in_flight == 0  # bytes reclaimed
+        assert cc.congestion_window == baseline_cwnd  # cwnd unchanged
+        assert cc.ssthresh is None  # slow-start preserved
+        assert self.ONE_RTT_SPACE.ack_eliciting_in_flight == 0
+        assert 0 not in self.ONE_RTT_SPACE.sent_packets
+
+    def test_pmtu_probe_loss_fires_delivery_handler(self):
+        captured: list[QuicDeliveryState] = []
+
+        def handler(state: QuicDeliveryState, *args) -> None:
+            captured.append(state)
+
+        probe = self._probe_packet(pn=0, sent_time=0.0)
+        probe.delivery_handlers = [(handler, ())]
+        self.recovery.on_packet_sent(probe, self.ONE_RTT_SPACE)
+
+        self.recovery._on_packets_lost(
+            [probe], space=self.ONE_RTT_SPACE, now=1.0
+        )
+        assert captured == [QuicDeliveryState.LOST]
+
+    def test_pmtu_probe_excluded_from_persistent_congestion(self):
+        # Two PMTU probes lost over a long span MUST NOT trigger
+        # persistent-congestion collapse.
+        cc = self.recovery._cc
+        # Establish RTT sample so persistent-congestion eligibility is met.
+        normal = QuicSentPacket(
+            epoch=tls.Epoch.ONE_RTT,
+            in_flight=True,
+            is_ack_eliciting=True,
+            is_crypto_packet=False,
+            packet_number=100,
+            packet_type=QuicPacketType.ONE_RTT,
+            sent_bytes=1280,
+            sent_time=0.0,
+        )
+        self.recovery.on_packet_sent(normal, self.ONE_RTT_SPACE)
+        rs = RangeSet()
+        rs.add(100, 101)
+        self.recovery.on_ack_received(
+            self.ONE_RTT_SPACE, ack_rangeset=rs, ack_delay=0.0, now=0.05
+        )
+        baseline_cwnd = cc.congestion_window
+        assert self.recovery._rtt_initialized
+
+        p1 = self._probe_packet(pn=200, sent_time=10.0)
+        p2 = self._probe_packet(pn=201, sent_time=20.0)
+        self.recovery.on_packet_sent(p1, self.ONE_RTT_SPACE)
+        self.recovery.on_packet_sent(p2, self.ONE_RTT_SPACE)
+
+        self.recovery._on_packets_lost(
+            [p1, p2], space=self.ONE_RTT_SPACE, now=21.0
+        )
+        # No collapse, no halving, slow-start preserved, cwnd unchanged.
+        assert cc.ssthresh is None
+        assert cc.congestion_window == baseline_cwnd
+        assert cc.bytes_in_flight == 0
+
+    def test_non_probe_loss_still_reduces_cwnd(self):
+        # Sanity: regular ack-eliciting in-flight loss DOES reduce cwnd.
+        cc = self.recovery._cc
+        baseline_cwnd = cc.congestion_window
+
+        regular = QuicSentPacket(
+            epoch=tls.Epoch.ONE_RTT,
+            in_flight=True,
+            is_ack_eliciting=True,
+            is_crypto_packet=False,
+            packet_number=0,
+            packet_type=QuicPacketType.ONE_RTT,
+            sent_bytes=1280,
+            sent_time=10.0,
+        )
+        self.recovery.on_packet_sent(regular, self.ONE_RTT_SPACE)
+        self.recovery._on_packets_lost(
+            [regular], space=self.ONE_RTT_SPACE, now=11.0
+        )
+        assert cc.congestion_window < baseline_cwnd
+        assert cc.ssthresh is not None
+
+    def test_pmtu_probe_does_not_arm_pto(self):
+        # RFC 9000 14.4: a PMTU probe MUST NOT anchor
+        # the standard loss-detection / PTO timer.
+        probe = self._probe_packet(pn=0, sent_time=0.0)
+        self.recovery.on_packet_sent(probe, self.ONE_RTT_SPACE)
+
+        # Only a PMTU probe is in flight: ack_eliciting_in_flight stays 0,
+        # so get_loss_detection_time returns None (no PTO armed).
+        assert self.ONE_RTT_SPACE.ack_eliciting_in_flight == 0
+        assert self.recovery.get_loss_detection_time() is None
+        # Bytes are still in flight (probe consumes cwnd).
+        assert self.recovery.bytes_in_flight == 1452
+
+    def test_regular_packet_alongside_probe_drives_pto(self):
+        # If a regular ack-eliciting packet is in flight alongside the
+        # probe, PTO is anchored on the regular packet only.
+        regular = QuicSentPacket(
+            epoch=tls.Epoch.ONE_RTT,
+            in_flight=True,
+            is_ack_eliciting=True,
+            is_crypto_packet=False,
+            packet_number=10,
+            packet_type=QuicPacketType.ONE_RTT,
+            sent_bytes=1280,
+            sent_time=5.0,
+        )
+        probe = self._probe_packet(pn=11, sent_time=99.0)
+        self.recovery.on_packet_sent(regular, self.ONE_RTT_SPACE)
+        self.recovery.on_packet_sent(probe, self.ONE_RTT_SPACE)
+
+        assert self.ONE_RTT_SPACE.ack_eliciting_in_flight == 1
+        # PTO time anchored on regular (sent_time=5.0), not probe (99.0).
+        pto = self.recovery.get_loss_detection_time()
+        assert pto is not None
+        assert pto < 99.0
+
+    def test_pmtu_probe_ack_does_not_underflow_counter(self):
+        # Symmetric accounting: ACKing the probe must not decrement
+        # ack_eliciting_in_flight below zero.
+        probe = self._probe_packet(pn=0, sent_time=0.0)
+        self.recovery.on_packet_sent(probe, self.ONE_RTT_SPACE)
+        assert self.ONE_RTT_SPACE.ack_eliciting_in_flight == 0
+
+        rs = RangeSet()
+        rs.add(0, 1)
+        self.recovery.on_ack_received(
+            self.ONE_RTT_SPACE, ack_rangeset=rs, ack_delay=0.0, now=0.05
+        )
+        assert self.ONE_RTT_SPACE.ack_eliciting_in_flight == 0
+        assert self.recovery.bytes_in_flight == 0
+
+
 def _hystart_packet(pn: int, sent_time: float, size: int = 1280) -> QuicSentPacket:
     return QuicSentPacket(
         epoch=tls.Epoch.ONE_RTT,

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -10,6 +10,7 @@ from qh3._hazmat import RangeSet, QuicPacketPacer, QuicRttMonitor
 from qh3.quic.packet_builder import QuicDeliveryState
 from qh3.quic.recovery import (
     K_MINIMUM_WINDOW,
+    K_HYSTART_CSS_ROUNDS,
     QuicCongestionControl,
     QuicPacketRecovery,
     QuicPacketSpace,
@@ -385,6 +386,169 @@ class TestQuicPacketRecovery:
         cc.on_packet_sent(old)
         cc.on_packets_lost([old], now=101.0)
         assert cc.ssthresh is None  # slow-start still alive
+
+
+def _hystart_packet(pn: int, sent_time: float, size: int = 1280) -> QuicSentPacket:
+    return QuicSentPacket(
+        epoch=tls.Epoch.ONE_RTT,
+        in_flight=True,
+        is_ack_eliciting=True,
+        is_crypto_packet=False,
+        packet_number=pn,
+        packet_type=QuicPacketType.ONE_RTT,
+        sent_bytes=size,
+        sent_time=sent_time,
+    )
+
+
+class TestHyStartPlusPlus:
+    """RFC 9406 HyStart++ behavioural tests on QuicCongestionControl."""
+
+    def _drive_round(
+        self,
+        cc: QuicCongestionControl,
+        first_pn: int,
+        rtt: float,
+        n_acks: int = 8,
+        send_time: float = 0.0,
+    ) -> int:
+        """Send N packets and ACK each one, supplying rtt per ACK.
+
+        Mirrors qh3's real ``QuicPacketRecovery.on_ack_received`` ordering:
+        on_packet_acked is invoked per acked packet first, and
+        on_rtt_measurement is invoked once after the loop. We feed an
+        RTT sample per ACK here (HyStart++ is sample-driven). This keeps
+        the RFC 9406 ordering, round-end detection happens before a new
+        sample is added to the next round.
+
+        Returns the next PN to use for the following round.
+        """
+        for i in range(n_acks):
+            cc.on_packet_sent(_hystart_packet(first_pn + i, send_time + i * 0.0001))
+        now = send_time + 0.001
+        for i in range(n_acks):
+            cc.on_packet_acked(_hystart_packet(first_pn + i, send_time + i * 0.0001))
+            cc.on_rtt_measurement(rtt, now)
+        return first_pn + n_acks
+
+    def test_default_enabled(self):
+        cc = QuicCongestionControl(max_datagram_size=1280)
+        # Per RFC 9406 recommendation HyStart++ is on by default.
+        assert cc.hystart_enabled is True
+        assert cc._hystart_in_css is False
+        assert cc.ssthresh is None
+
+    def test_steady_rtt_keeps_slow_start_active(self):
+        """A flat RTT profile must NOT trip HyStart into CSS."""
+        cc = QuicCongestionControl(max_datagram_size=1280)
+        next_pn = 0
+        # 5 bursts (each closes the previous round), RTT pinned at 50 ms.
+        for r in range(5):
+            next_pn = self._drive_round(
+                cc, next_pn, rtt=0.050, send_time=r * 0.1
+            )
+        assert cc._hystart_in_css is False
+        assert cc.ssthresh is None  # still in slow start
+
+    def test_rtt_inflation_enters_css(self):
+        """An RTT jump above the threshold must enter CSS.
+
+        Each burst closes the round of the prior burst, so three bursts
+        are required: burst-1 (baseline) populates round-1, burst-2's
+        first ACK propagates last_round_min_rtt to baseline, burst-3
+        at the inflated RTT trips the SS-exit check.
+        """
+        cc = QuicCongestionControl(max_datagram_size=1280)
+        # Burst 1: baseline 20 ms; populates round-1 samples.
+        next_pn = self._drive_round(cc, 0, rtt=0.020, send_time=0.0)
+        # Burst 2: still 20 ms; closes round-1 (last_min = 0.020), fills round-2.
+        next_pn = self._drive_round(cc, next_pn, rtt=0.020, send_time=0.1)
+        assert cc._hystart_last_round_min_rtt == pytest.approx(0.020)
+        assert cc._hystart_in_css is False
+        # Burst 3: inflated to 50 ms (well above the 4 ms threshold).
+        next_pn = self._drive_round(cc, next_pn, rtt=0.050, send_time=0.2)
+        assert cc._hystart_in_css is True
+        assert cc.ssthresh is None  # CSS keeps cwnd in slow-start regime
+
+    def test_css_growth_uses_divisor(self):
+        """In CSS, cwnd grows by sent_bytes/4 instead of sent_bytes."""
+        cc = QuicCongestionControl(max_datagram_size=1280)
+        # Force CSS without going through full RTT-sample dance.
+        cc._hystart_in_css = True
+        cc._hystart_window_end = 1_000_000  # well above any acked PN below
+        cwnd0 = cc.congestion_window
+        pkt = _hystart_packet(pn=0, sent_time=0.0, size=1280)
+        cc.on_packet_sent(pkt)
+        cc.on_packet_acked(pkt)
+        # 1280 // 4 == 320
+        assert cc.congestion_window == cwnd0 + 320
+
+    def test_css_completes_after_five_rounds_then_exits_to_ca(self):
+        cc = QuicCongestionControl(max_datagram_size=1280)
+        # Bursts 1+2: baseline 20 ms (sets last_round_min_rtt = 0.020).
+        next_pn = self._drive_round(cc, 0, rtt=0.020, send_time=0.0)
+        next_pn = self._drive_round(cc, next_pn, rtt=0.020, send_time=0.1)
+        # Burst 3: inflated -> CSS.
+        next_pn = self._drive_round(cc, next_pn, rtt=0.050, send_time=0.2)
+        assert cc._hystart_in_css is True
+        # Now drive CSS_ROUNDS+1 additional bursts at the inflated RTT
+        # (each new burst closes the prior round; one extra is needed to
+        # close the final CSS round).
+        send_t = 0.3
+        for _ in range(K_HYSTART_CSS_ROUNDS + 1):
+            next_pn = self._drive_round(cc, next_pn, rtt=0.050, send_time=send_t)
+            send_t += 0.1
+        # CSS budget exhausted -> ssthresh pinned, in_css cleared.
+        # cwnd may grow slightly past ssthresh between the SS exit and
+        # the CA path taking over on subsequent ACKs.
+        assert cc._hystart_in_css is False
+        assert cc.ssthresh is not None
+        assert cc.ssthresh <= cc.congestion_window
+
+    def test_css_false_trigger_returns_to_slow_start(self):
+        """CSS must abandon and revert to SS when current round RTT
+        falls back below the CSS baseline (false trigger detection,
+        RFC 9406 4.3)."""
+        cc = QuicCongestionControl(max_datagram_size=1280)
+        # Bursts 1+2: baseline 20 ms.
+        next_pn = self._drive_round(cc, 0, rtt=0.020, send_time=0.0)
+        next_pn = self._drive_round(cc, next_pn, rtt=0.020, send_time=0.1)
+        # Burst 3: inflated -> CSS.
+        next_pn = self._drive_round(cc, next_pn, rtt=0.050, send_time=0.2)
+        assert cc._hystart_in_css is True
+        baseline = cc._hystart_css_baseline_min_rtt
+        # Burst 4 at improved RTT (well below CSS baseline) closes round
+        # 3 (which was inflated); burst 5 fills a CSS round with the
+        # improved RTT and triggers the false-trigger path.
+        next_pn = self._drive_round(
+            cc, next_pn, rtt=baseline - 0.010, send_time=0.3
+        )
+        self._drive_round(
+            cc, next_pn, rtt=baseline - 0.010, send_time=0.4
+        )
+        assert cc._hystart_in_css is False
+        assert cc.ssthresh is None  # back to standard slow start
+
+    def test_disable_falls_back_to_legacy_monitor(self):
+        cc = QuicCongestionControl(max_datagram_size=1280)
+        cc.hystart_enabled = False
+        # Even with rtt inflation HyStart++ state stays untouched...
+        cc.on_rtt_measurement(0.050, now=1.0)
+        assert cc._hystart_rtt_sample_count == 0
+        assert cc._hystart_in_css is False
+
+    def test_persistent_congestion_resets_hystart(self):
+        cc = QuicCongestionControl(max_datagram_size=1280)
+        # Drive into CSS first (3 bursts: baseline, baseline, inflated).
+        next_pn = self._drive_round(cc, 0, rtt=0.020, send_time=0.0)
+        next_pn = self._drive_round(cc, next_pn, rtt=0.020, send_time=0.1)
+        self._drive_round(cc, next_pn, rtt=0.050, send_time=0.2)
+        assert cc._hystart_in_css is True
+        cc.on_persistent_congestion(now=200.0)
+        assert cc._hystart_in_css is False
+        assert cc._hystart_window_end is None
+        assert cc._hystart_rtt_sample_count == 0
+        assert math.isinf(cc._hystart_last_round_min_rtt)
 
 
 class TestQuicRttMonitor:

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -7,7 +7,10 @@ from qh3 import tls
 from qh3.quic.packet import QuicPacketType
 from qh3.quic.packet_builder import QuicSentPacket
 from qh3._hazmat import RangeSet, QuicPacketPacer, QuicRttMonitor
+from qh3.quic.packet_builder import QuicDeliveryState
 from qh3.quic.recovery import (
+    K_MINIMUM_WINDOW,
+    QuicCongestionControl,
     QuicPacketRecovery,
     QuicPacketSpace,
 )
@@ -174,6 +177,214 @@ class TestQuicPacketRecovery:
         assert self.recovery.bytes_in_flight == 0
         assert space.ack_eliciting_in_flight == 0
         assert len(space.sent_packets) == 0
+
+    def test_reschedule_data_app_uses_rescheduled_path(self):
+        # Application-data packet in flight; PTO triggers reschedule
+        # (RFC 9002 6.2.4). Bytes must be reclaimed and the LOST handler
+        # fired, but cwnd MUST NOT shrink and _pto_count MUST NOT reset.
+        packet = QuicSentPacket(
+            epoch=tls.Epoch.ONE_RTT,
+            in_flight=True,
+            is_ack_eliciting=True,
+            is_crypto_packet=False,
+            packet_number=0,
+            packet_type=QuicPacketType.ONE_RTT,
+            sent_bytes=1280,
+            sent_time=0.0,
+        )
+        observed = []
+
+        def _handler(state):
+            observed.append(state)
+
+        packet.delivery_handlers = [(_handler, ())]
+        self.recovery.on_packet_sent(packet, self.ONE_RTT_SPACE)
+
+        cwnd_before = self.recovery._cc.congestion_window
+        self.recovery._pto_count = 2
+
+        self.recovery.reschedule_data(now=5.0)
+
+        assert observed == [QuicDeliveryState.LOST]
+        assert self.recovery.bytes_in_flight == 0
+        assert self.recovery._cc.congestion_window == cwnd_before
+        assert self.recovery._pto_count == 2
+        assert len(self.ONE_RTT_SPACE.sent_packets) == 0
+
+    def test_on_ack_received_initial_does_not_reset_pto_count(self):
+        # RFC 9002 6.2.1: a client MUST NOT reset its PTO backoff on
+        # ACKs that only acknowledge Initial packets.
+        packet = QuicSentPacket(
+            epoch=tls.Epoch.INITIAL,
+            in_flight=True,
+            is_ack_eliciting=True,
+            is_crypto_packet=True,
+            packet_number=0,
+            packet_type=QuicPacketType.INITIAL,
+            sent_bytes=1280,
+            sent_time=0.0,
+        )
+        self.recovery.on_packet_sent(packet, self.INITIAL_SPACE)
+        self.recovery._pto_count = 3
+
+        rs = RangeSet()
+        rs.add(0, 1)
+        self.recovery.on_ack_received(
+            self.INITIAL_SPACE,
+            ack_rangeset=rs,
+            ack_delay=0.0,
+            now=10.0,
+            reset_pto_count=False,
+        )
+        assert self.recovery._pto_count == 3
+
+        # control: default behaviour does reset
+        packet2 = QuicSentPacket(
+            epoch=tls.Epoch.ONE_RTT,
+            in_flight=True,
+            is_ack_eliciting=True,
+            is_crypto_packet=False,
+            packet_number=0,
+            packet_type=QuicPacketType.ONE_RTT,
+            sent_bytes=1280,
+            sent_time=10.0,
+        )
+        self.recovery.on_packet_sent(packet2, self.ONE_RTT_SPACE)
+        rs2 = RangeSet()
+        rs2.add(0, 1)
+        self.recovery.on_ack_received(
+            self.ONE_RTT_SPACE, ack_rangeset=rs2, ack_delay=0.0, now=11.0
+        )
+        assert self.recovery._pto_count == 0
+
+    def test_persistent_congestion_detected(self):
+        # RFC 9002 7.6: if at least two ack-eliciting packets are
+        # declared lost over a span longer than the persistent
+        # congestion threshold, cwnd collapses to MIN.
+        # Prime an RTT estimate so _rtt_initialized is True.
+        prime = QuicSentPacket(
+            epoch=tls.Epoch.ONE_RTT,
+            in_flight=True,
+            is_ack_eliciting=True,
+            is_crypto_packet=False,
+            packet_number=0,
+            packet_type=QuicPacketType.ONE_RTT,
+            sent_bytes=1280,
+            sent_time=0.0,
+        )
+        self.recovery.on_packet_sent(prime, self.ONE_RTT_SPACE)
+        rs = RangeSet()
+        rs.add(0, 1)
+        self.recovery.on_ack_received(
+            self.ONE_RTT_SPACE, ack_rangeset=rs, ack_delay=0.0, now=0.05
+        )
+        assert self.recovery._rtt_initialized
+
+        # send three ack-eliciting packets spread far apart in time
+        for i, t in enumerate([1.0, 6.0, 11.0], start=1):
+            self.recovery.on_packet_sent(
+                QuicSentPacket(
+                    epoch=tls.Epoch.ONE_RTT,
+                    in_flight=True,
+                    is_ack_eliciting=True,
+                    is_crypto_packet=False,
+                    packet_number=i,
+                    packet_type=QuicPacketType.ONE_RTT,
+                    sent_bytes=1280,
+                    sent_time=t,
+                ),
+                self.ONE_RTT_SPACE,
+            )
+
+        cwnd_before = self.recovery._cc.congestion_window
+        assert cwnd_before > 1280 * K_MINIMUM_WINDOW
+
+        # ACK only the newest, forcing the older two into the lost set
+        # via packet-threshold detection.
+        ack = RangeSet()
+        ack.add(3, 4)
+        self.recovery.on_ack_received(
+            self.ONE_RTT_SPACE, ack_rangeset=ack, ack_delay=0.0, now=11.05
+        )
+
+        # Persistent congestion collapsed cwnd to MIN.
+        assert self.recovery._cc.congestion_window == 1280 * K_MINIMUM_WINDOW
+        assert self.recovery._cc.ssthresh is None
+
+
+    def test_reset_for_new_path_clears_rtt_state(self):
+        """RFC 9000 9.4 / RFC 9002 5.1: path migration MUST clear RTT
+        samples from the prior path; in particular min_rtt would
+        otherwise pin loss_delay too low on a higher-latency path."""
+        # Seed loss recovery with samples from "old path".
+        self.recovery._rtt_initialized = True
+        self.recovery._rtt_latest = 0.050
+        self.recovery._rtt_latest_raw = 0.050
+        self.recovery._rtt_min = 0.040
+        self.recovery._rtt_smoothed = 0.045
+        self.recovery._rtt_variance = 0.005
+
+        self.recovery.reset_for_new_path()
+
+        assert self.recovery._rtt_initialized is False
+        assert self.recovery._rtt_latest == 0.0
+        assert self.recovery._rtt_latest_raw == 0.0
+        assert self.recovery._rtt_min == math.inf
+        assert self.recovery._rtt_smoothed == 0.0
+        assert self.recovery._rtt_variance == 0.0
+
+    def test_on_persistent_congestion_collapses_state(self):
+        cc = QuicCongestionControl(max_datagram_size=1280)
+
+        # set non-trivial state
+        cc.congestion_window = 100_000
+        cc.ssthresh = 80_000
+        cc._first_slow_start = False
+        cc._starting_congestion_avoidance = True
+        cc._K = 2.5
+        cc._W_max = 120_000
+        cc._W_est = 99_000
+        cc._cwnd_epoch = 42
+        cc._t_epoch = 10.0
+        cc._congestion_recovery_start_time = 1.0
+
+        cc.on_persistent_congestion(now=123.0)
+
+        assert cc._congestion_recovery_start_time == 123.0
+        assert cc.congestion_window == 1280 * K_MINIMUM_WINDOW
+        assert cc.ssthresh is None
+        assert cc._first_slow_start is True
+        assert cc._starting_congestion_avoidance is False
+        assert cc._K == 0.0
+        assert cc._W_max == cc.congestion_window
+        assert cc._W_est == 0
+        assert cc._cwnd_epoch == 0
+        assert cc._t_epoch == 0.0
+
+    def test_post_collapse_loss_does_not_pin_ssthresh(self):
+        # Regression guard: previously _congestion_recovery_start_time
+        # was reset to 0.0, so the very next loss after collapse passed
+        # the recovery-period guard in on_packets_lost and pinned
+        # ssthresh = MINIMUM_WINDOW, terminating slow-start permanently.
+        cc = QuicCongestionControl(max_datagram_size=1280)
+        cc.on_persistent_congestion(now=100.0)
+        assert cc.ssthresh is None
+
+        # A packet sent BEFORE the collapse and declared lost AFTER
+        # must not start a fresh congestion event.
+        old = QuicSentPacket(
+            epoch=tls.Epoch.ONE_RTT,
+            in_flight=True,
+            is_ack_eliciting=True,
+            is_crypto_packet=False,
+            packet_number=0,
+            packet_type=QuicPacketType.ONE_RTT,
+            sent_bytes=1280,
+            sent_time=50.0,
+        )
+        cc.on_packet_sent(old)
+        cc.on_packets_lost([old], now=101.0)
+        assert cc.ssthresh is None  # slow-start still alive
 
 
 class TestQuicRttMonitor:

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -224,6 +224,21 @@ class TestQuicStream:
             stream.receiver.handle_reset(final_size=5)
         assert str(cm.value) == "Cannot change final size"
 
+    def test_handle_reset_shrinks_final_size(self):
+        # RFC 9000 4.5: a RESET_STREAM whose Final Size is below what has
+        # already been received MUST be treated as FINAL_SIZE_ERROR.
+        stream = QuicStream(stream_id=0)
+        stream.receiver.handle_frame(0, b"0123456789")
+        assert stream.receiver.highest_offset == 10
+
+        with pytest.raises(FinalSizeError) as cm:
+            stream.receiver.handle_reset(final_size=4)
+        assert "below already-received" in str(cm.value)
+        # State must be unchanged on rejection.
+        assert stream.receiver._final_size is None
+        assert stream.receiver.highest_offset == 10
+        assert not stream.receiver.is_finished
+
     def test_receiver_stop(self):
         stream = QuicStream()
 


### PR DESCRIPTION
1.8.1 (2026-05-07)
==================

**Fixed**
- Remediation on various QUIC compliance items (enabled by 3rd party audit).
  - fix(recovery): compliance batch
  - fix(crypto): retain previous recv keys for 3 PTO
  - fix(connection): stateless reset, CONNECTION_CLOSE retransmit, idle-timer floor
  - fix(stream): FINAL_SIZE_ERROR, send-only stream cleanup
  - fix(h3): surface StreamReset / StopSending events; enforce critical stream closure
  - fix(packet): reject duplicate transport parameters
  - fix(recovery): implement missing HyStart++
  - chore: raise initial_rtt default to 333 ms
