### PR TITLE
chore: examples: update ports and ALPN for the DoQ examples to RFC 9250

### DIFF
--- a/examples/README.rst
+++ b/examples/README.rst
@@ -101,15 +101,22 @@ DNS over QUIC
 By default the server will use the `Google Public DNS`_ service, you can
 override this with the ``--resolver`` argument.
 
+By default the server will listen for requests on port 853, which requires
+a privileged user. You can override this with the `--port` argument.
+
+You can run the server locally using:
+
 .. code-block:: console
 
-    python examples/doq_server.py --certificate tests/ssl_cert.pem --private-key tests/ssl_key.pem
+    python examples/doq_server.py --certificate tests/ssl_cert.pem --private-key tests/ssl_key.pem --port 8053
 
 You can then run the client with a specific query:
 
 .. code-block:: console
 
-    python examples/doq_client.py --ca-certs tests/pycacert.pem --query-type "A" --query-name "quic.aiortc.org" --port 4784
+    python examples/doq_client.py --ca-certs tests/pycacert.pem --query-type A --query-name quic.aiortc.org --port 8053
+
+Please note that for real-world usage you will need to obtain a valid TLS certificate.
 
 .. _Google Public DNS: https://developers.google.com/speed/public-dns
 .. _--enable-experimental-web-platform-features: https://peter.sh/experiments/chromium-command-line-switches/#enable-experimental-web-platform-features

--- a/examples/doq_client.py
+++ b/examples/doq_client.py
@@ -96,7 +96,7 @@ if __name__ == "__main__":
         help="The remote peer's host name or IP address",
     )
     parser.add_argument(
-        "--port", type=int, default=784, help="The remote peer's port number"
+        "--port", type=int, default=853, help="The remote peer's port number"
     )
     parser.add_argument(
         "-k",
@@ -138,7 +138,7 @@ if __name__ == "__main__":
         level=logging.DEBUG if args.verbose else logging.INFO,
     )
 
-    configuration = QuicConfiguration(alpn_protocols=["doq-i03"], is_client=True)
+    configuration = QuicConfiguration(alpn_protocols=["doq"], is_client=True)
     if args.ca_certs:
         configuration.load_verify_locations(args.ca_certs)
     if args.insecure:

--- a/examples/doq_server.py
+++ b/examples/doq_server.py
@@ -74,8 +74,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--port",
         type=int,
-        default=4784,
-        help="listen on the specified port (defaults to 4784)",
+        default=853,
+        help="listen on the specified port (defaults to 853)",
     )
     parser.add_argument(
         "-k",
@@ -125,7 +125,7 @@ if __name__ == "__main__":
         quic_logger = None
 
     configuration = QuicConfiguration(
-        alpn_protocols=["doq-i03"],
+        alpn_protocols=["doq"],
         is_client=False,
         quic_logger=quic_logger,
     )


### PR DESCRIPTION
Copied from the respective commit in the aioquic repo:

author Jan Hák <jan.hak@nic.cz> Thu Jun 8 14:33:56 2023 +0200 committer Jeremy Lainé <jeremy.laine@m4x.org> Tue Jul 4 18:38:41 2023 +0200


Original-commit-hash: 544652ab86f9b2d2c2d6513b80ef39a7a0463eb7